### PR TITLE
@FIR-816: Add ability to select whether to run natively or on FPGA

### DIFF
--- a/open-webui-setup.sh
+++ b/open-webui-setup.sh
@@ -12,6 +12,7 @@ node -v
 npm -v
 nvm install 20.18.1
 nvm use 20.18.1
+pip install --upgrade chromadb
 ln -s $(pwd)/build backend/open_webui/frontend
 fi
 uv run open-webui serve


### PR DESCRIPTION
This change allows selecting FPGA as a target via custom parameters The changes does following
1. If custom parameter 'target' is undefined or is set to 'native' the Ollama target for chat is used
2. If the custom parameter 'target' is defined and is set to 'cpu' or 'tsi' the FPGA target is selected.
3. This custom parameter can be parsed in flask to decide on cpu versus tSavorite backend.
4. A minor change to update chromadb if it is not updated in venv environment

The test results are as follows:
 
<img width="2097" height="787" alt="Screenshot 2025-07-15 143721" src="https://github.com/user-attachments/assets/9cc23a23-94b2-4b6b-98fa-35610344df0b" />
<img width="2110" height="900" alt="Screenshot 2025-07-15 143812" src="https://github.com/user-attachments/assets/b56b0468-f52e-417d-8fb5-8fc071e8a243" />
<img width="2117" height="873" alt="Screenshot 2025-07-15 143843" src="https://github.com/user-attachments/assets/72fdc2e9-e38f-4bc2-8e72-f8a739e3e5e2" />
<img width="2104" height="1150" alt="Screenshot 2025-07-15 145410" src="https://github.com/user-attachments/assets/da7bf2f1-bd34-454c-8f15-5b3b6e7c452b" />
<img width="2096" height="1138" alt="Screenshot 2025-07-15 144039" src="https://github.com/user-attachments/assets/6c7640a8-34b4-4a90-a4ed-94ecd585ba04" />
