### PR TITLE
@FIR-824: Fix the title page to show TSI WebUI instead of Open WebUI

### DIFF
--- a/open-webui-setup.sh
+++ b/open-webui-setup.sh
@@ -10,6 +10,7 @@ uv pip install -r backend/requirements.txt
 pip install npm
 node -v
 npm -v
+export WEBUI_NAME="TSI WebUI"
 nvm install 20.18.1
 nvm use 20.18.1
 pip install --upgrade chromadb


### PR DESCRIPTION
This change fixes the title on front login page and the table title to reflect TSI WebUI instead of Open WebUI as follows

<img width="1334" height="674" alt="Screenshot 2025-07-17 191523" src="https://github.com/user-attachments/assets/5a4c6693-d7aa-4e59-b5fe-c59d9488adea" />
<img width="1331" height="691" alt="Screenshot 2025-07-17 192034" src="https://github.com/user-attachments/assets/e55de556-eaa2-4e2a-8d0f-8b6a307ecc5f" />
