### PR TITLE
@FIR-845: Parse model name from the request and add raw text for usage

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -457,7 +457,6 @@ def chats():
     serial_script.pre_and_post_check(port,baudrate)
     
     data = request.get_json()
-    
     if 'options' in data:
         for item in parameters:
             if item in data['options']:
@@ -467,14 +466,16 @@ def chats():
     flattened_prompt = re.sub(r'\s+', ' ', original_prompt).strip()
     tmpprompt = flattened_prompt.replace('"', '\\"').encode('utf-8')
     prompt = tmpprompt.decode('utf-8')
-      
-    model = DEFAULT_MODEL
+
+    #model = DEFAULT_MODEL
 
     if parameters['target'] == 'cpu':
         backend = 'none'
     elif parameters['target'] == 'opu':
         backend = 'tSavorite'
-    
+    if 'model' in data:
+        model = data['model']
+    model = DEFAULT_MODEL
     tokens = parameters['num_predict']
     repeat_penalty = parameters['repeat_penalty']
     batch_size = parameters['num_batch']
@@ -487,7 +488,7 @@ def chats():
     # Define the model path (update with actual paths)
     model_paths = {
         "tiny-llama": "tinyllama-vo-5m-para.gguf",
-        "Tiny-llama-F32": "Tiny-Llama-v0.3-FP32-1.1B-F32.gguf"
+        "TinyLlama:latest": "Tiny-Llama-v0.3-FP32-1.1B-F32.gguf"
     }
     model_path = model_paths.get(model, "")
     if not model_path:
@@ -559,13 +560,15 @@ def chat():
     tmpprompt = flattened_prompt.replace('"', '\\"').encode('utf-8')
     prompt = tmpprompt.decode('utf-8')
       
-    model = DEFAULT_MODEL
+    #model = DEFAULT_MODEL
 
     if parameters['target'] == 'cpu':
         backend = 'none'
     elif parameters['target'] == 'opu':
         backend = 'tSavorite'
-    
+    if 'model' in data:
+        model = data['model']
+    model = DEFAULT_MODEL
     tokens = parameters['num_predict']
     repeat_penalty = parameters['repeat_penalty']
     batch_size = parameters['num_batch']
@@ -578,7 +581,7 @@ def chat():
     # Define the model path (update with actual paths)
     model_paths = {
         "tiny-llama": "tinyllama-vo-5m-para.gguf",
-        "Tiny-llama-F32": "Tiny-Llama-v0.3-FP32-1.1B-F32.gguf"
+        "TinyLlama:latest": "Tiny-Llama-v0.3-FP32-1.1B-F32.gguf"
     }
     model_path = model_paths.get(model, "")
     if not model_path:

--- a/backend/open_webui/utils/response.py
+++ b/backend/open_webui/utils/response.py
@@ -131,7 +131,8 @@ def extract_llama_cpp_metrics(perf_text):
                 "reasoning_tokens": 0,
                 "accepted_prediction_tokens": 0,
                 "rejected_prediction_tokens": 0
-            }
+            },
+            "raw": perf_text
     }
     return metrics
 

--- a/src/lib/components/chat/ProfileChatModal.svelte
+++ b/src/lib/components/chat/ProfileChatModal.svelte
@@ -87,9 +87,9 @@
 	}
 </script>
 
-<Modal bind:show size="md">
+<Modal bind:show size="lg">
 	<div>
-		<div class=" flex justify-between dark:text-gray-300 px-5 pt-4 pb-0.5">
+		<div class=" flex justify-between w-full dark:text-gray-300 px-5 pt-4 pb-0.5">
 			<div class=" text-lg font-medium self-center">{$i18n.t('Chat Profile Data')}</div>
 			<button
 				class="self-center"
@@ -110,13 +110,12 @@
 							<div class="grid grid-cols-2 gap-x-6 gap-y-2 border rounded p-4 bg-gray-50">
 								{#each Object.entries(usage) as [key, value]}
 									<div class="font-medium text-left text-gray-700">{key}</div>
-									<div class="text-gray-900 text-left">{String(value)}</div>
+									<pre class="w-full max-w-[1200px] overflow-auto whitespace-pre-wrap font-mono text-sm bg-gray-100 border rounded p-4">{String(value)}</pre>
 								{/each}
 							</div>
 						{/each}
 					{:else}
 						<p>No usage blocks found yet.</p>
-						<pre>{JSON.stringify(chat, null, 2)}</pre>
 					{/if}
 				</div>
 			</div>


### PR DESCRIPTION
This change has following
1. Add parsing of model name from request, but till continue to hard code the model, I have also left the commented code in place to be able to uncomment once we remove the default.
2. Map bigger model name to TinyLlama:latest string
3. Rearrange the modal and display the raw output in the usage at the bottom

The test results are as follows:
<img width="2078" height="1265" alt="Screenshot 2025-07-25 094040" src="https://github.com/user-attachments/assets/72d111c0-9e20-40ac-b59f-b84d501d42da" />
