### PR TITLE
@FIR-847: Add support for abort task or chat

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -652,6 +652,18 @@ def health_check_ollama_serial_command():
     result, error = health_check_serial_command()
     return manual_response(content=result,thinking="Health Check"), error
 
+def aborttask():
+    try:
+        result = serial_script.abort_serial_portion(port,baudrate)
+        return result, 200
+    except subprocess.CalledProcessError as e:
+        return f"Error executing script: {e.stderr}", 500
+
+@app.route('/api/abort-task', methods=['GET', 'POST'])
+def abort_task_ollama_serial_command():
+    result, error = aborttask()
+    return manual_response(content=result,thinking="Abort Task"), error
+
 @app.route('/submit', methods=['POST'])
 def submit():
 

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -1478,6 +1478,24 @@ async def healthcheck_opu(
         user=user,
     )
 
+@router.post("/api/aborttaskopu")
+async def aborttask_opu(
+    request: Request,
+    form_data: dict,
+    url_idx: Optional[int] = None,
+    user=Depends(get_verified_user),
+    bypass_filter: Optional[bool] = False,
+):
+    url = DEFAULT_FLASK_URL
+    return await send_post_request(
+        url=f"{url}/api/abort-task",
+        payload=None,
+        stream=False,
+        key=None,
+        content_type="application/x-ndjson",
+        user=user,
+    )
+
 # TODO: we should update this part once Ollama supports other types
 class OpenAIChatMessageContent(BaseModel):
     type: str

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -83,6 +83,7 @@
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Navbar from '$lib/components/chat/Navbar.svelte';
 	import ChatControls from './ChatControls.svelte';
+	import {abortTaskOpu} from './Controls/Controls.svelte';
 	import EventConfirmDialog from '../common/ConfirmDialog.svelte';
 	import Placeholder from './Placeholder.svelte';
 	import NotificationToast from '../NotificationToast.svelte';
@@ -1835,6 +1836,11 @@
 	};
 
 	const stopResponse = async () => {
+		if (($user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true)) && (params.target === 'cpu' || params.target === 'opu')) {
+			const res = await abortTaskOpu().catch((error) => {
+				toast.error(`${error}`);
+			});
+		}
 		if (taskIds) {
 			for (const taskId of taskIds) {
 				const res = await stopTask(localStorage.token, taskId).catch((error) => {

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -74,6 +74,25 @@
                         return null;
                 }
         }
+	export async function abortTaskOpu() {
+                try {
+                        const response = await fetch('/ollama/api/aborttaskopu', {
+                                method: 'POST',
+                                headers: {
+                                        'Content-Type': 'application/json',
+                                },
+                                body: JSON.stringify({ target: 'opu' }),
+                        });
+                        if (!response.ok) throw new Error('System info failed');
+                        const data = await response.json(); // ✅ Parse JSON
+                        alert('Task aborted on OPU.');
+                        return data; // 🔁 Return the parsed object!
+                } catch (error) {
+                        console.error('Error System Info of OPU:', error);
+                        alert('Something went wrong while aborting task on OPU.');
+                        return null;
+                }
+        }
 </script>
 
 <div class=" dark:text-white">

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -12,7 +12,7 @@
 	import { v4 as uuidv4 } from 'uuid';
 	import { createPicker, getAuthToken } from '$lib/utils/google-drive-picker';
 	import { pickAndDownloadFile } from '$lib/utils/onedrive-file-picker';
-
+	import { abortTaskOpu} from './Controls/Controls.svelte';
 	import { onMount, tick, getContext, createEventDispatcher, onDestroy } from 'svelte';
 	const dispatch = createEventDispatcher();
 
@@ -1825,6 +1825,7 @@
 													<button
 														class="bg-white hover:bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5"
 														on:click={() => {
+															abortTaskOpu();
 															stopResponse();
 														}}
 													>

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -16,7 +16,7 @@
 
 	import { splitStream } from '$lib/utils';
 	import Collapsible from '../common/Collapsible.svelte';
-
+	import abortTaskOpu from '../chat/Controls/Controls.svelte';
 	import Messages from '$lib/components/playground/Chat/Messages.svelte';
 	import ChevronUp from '../icons/ChevronUp.svelte';
 	import ChevronDown from '../icons/ChevronDown.svelte';
@@ -55,6 +55,7 @@
 	};
 
 	const stopResponse = () => {
+		abortTaskOpu();
 		stopResponseFlag = true;
 		console.log('stopResponse');
 	};

--- a/src/lib/components/playground/Completions.svelte
+++ b/src/lib/components/playground/Completions.svelte
@@ -11,6 +11,7 @@
 	import { splitStream } from '$lib/utils';
 	import Selector from '$lib/components/chat/ModelSelector/Selector.svelte';
 	import MenuLines from '../icons/MenuLines.svelte';
+	import abortTaskOpu from '../chat/Controls/Controls.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -33,6 +34,7 @@
 	};
 
 	const stopResponse = () => {
+		abortTaskOpu();
 		stopResponseFlag = true;
 		console.log('stopResponse');
 	};


### PR DESCRIPTION
This change adds support for abort in the following
1. Abort Ollama endpoint support in flask
2. Ollama support for sending abort to OPU
3. Add abort support in message input, chat and completion
4. Add routing for aborting in controls routine.

The test results are as follows:
<img width="1341" height="597" alt="Screenshot 2025-07-28 063313" src="https://github.com/user-attachments/assets/0e319a5c-d2a4-4e14-857a-4dc25fe32b00" />
<img width="1348" height="582" alt="Screenshot 2025-07-28 063540" src="https://github.com/user-attachments/assets/242caef3-0770-4512-8db1-211941db12a4" />

