### PR TITLE
@FIR-849: Make default predictions as 12 and default model as TinyLlama

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -24,9 +24,9 @@ baudrate = '921600'
 #baudrate = '115200'
 exe_path = "/usr/bin/tsi/v0.1.1*/bin/"
 
-DEFAULT_MODEL = "tiny-llama"
+DEFAULT_MODEL = "TinyLlama:latest"
 DEFAULT_BACKEND = "tSavorite"
-DEFAULT_TOKEN = 10
+DEFAULT_TOKEN = 12
 DEFAULT_REPEAT_PENALTY = 1.5
 DEFAULT_BATCH_SIZE = 1024
 DEFAULT_TOP_K = 50
@@ -467,7 +467,7 @@ def chats():
     tmpprompt = flattened_prompt.replace('"', '\\"').encode('utf-8')
     prompt = tmpprompt.decode('utf-8')
 
-    #model = DEFAULT_MODEL
+    model = DEFAULT_MODEL
 
     if parameters['target'] == 'cpu':
         backend = 'none'
@@ -475,7 +475,7 @@ def chats():
         backend = 'tSavorite'
     if 'model' in data:
         model = data['model']
-    model = DEFAULT_MODEL
+
     tokens = parameters['num_predict']
     repeat_penalty = parameters['repeat_penalty']
     batch_size = parameters['num_batch']
@@ -560,7 +560,7 @@ def chat():
     tmpprompt = flattened_prompt.replace('"', '\\"').encode('utf-8')
     prompt = tmpprompt.decode('utf-8')
       
-    #model = DEFAULT_MODEL
+    model = DEFAULT_MODEL
 
     if parameters['target'] == 'cpu':
         backend = 'none'
@@ -568,7 +568,7 @@ def chat():
         backend = 'tSavorite'
     if 'model' in data:
         model = data['model']
-    model = DEFAULT_MODEL
+
     tokens = parameters['num_predict']
     repeat_penalty = parameters['repeat_penalty']
     batch_size = parameters['num_batch']


### PR DESCRIPTION
The change makes
1. Number of predictions default to 12 and anything non default will be used as is
2. Makes the TinyLlama:Latest as default

The Test Results are as follows:
The commands will show that default tokens to be generated is 12 if the number of tokens to be used is not passed otherwise it uses tokens what is passed and the default model is TinyLlama:Latest

root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv33_07_17_2025/bin# history
    1  history
    2  telnet localhost 8000
    3  ../install/tsi-start 
    4  trash
    5  trash
    6  trash
    7  trash
    8  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "My cat’s name is" 12 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf tSavorite 1.5 1024 50 0.9 5 12288 0.0
    9  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "### Task: Generate 1-3 broad tags categorizing the main themes of the chat history, along with 1-3 more specific subtopic tags. ### Guidelines: - Start with high-level domains (e.g. Science, Technology, Philosophy, Arts, Politics, Business, Health, Sports, Entertainment, Education) - Consider including relevant subfields/subdomains if they are strongly represented throughout the conversation - If content is too short (less than 3 messages) or too diverse, use only [\"General\"] - Use the chat's primary language; default to English if multilingual - Prioritize accuracy over specificity ### Output: JSON format: { \"tags\": [\"tag1\", \"tag2\", \"tag3\"] } ### Chat History: <chat_history> USER: My cat’s name is ASSISTANT: terminate called after throwing an instance of 'std::bad_array_new_length' what(): std::bad_array_new_length ./run_llama_cli.sh: line 28: 351 Aborted ./llama-cli -p \"${LLAMA_PROMPT}\" -m $LLAMA_MODEL_GGUF --device ${LLAMA_DEVICE} ${LLAMA_CMD_LINE} </chat_history>" 12 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf tSavorite 1.5 1024 50 0.9 5 12288 0.0
   10  trash
   11  trash
   12  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "### Task: Suggest 3-5 relevant follow-up questions or prompts that the user might naturally ask next in this conversation as a **user**, based on the chat history, to help continue or deepen the discussion. ### Guidelines: - Write all follow-up questions from the user’s point of view, directed to the assistant. - Make questions concise, clear, and directly related to the discussed topic(s). - Only suggest follow-ups that make sense given the chat content and do not repeat what was already covered. - If the conversation is very short or not specific, suggest more general (but relevant) follow-ups the user might ask. - Use the conversation's primary language; default to English if multilingual. - Response must be a JSON array of strings, no extra text or formatting. ### Output: JSON format: { \"follow_ups\": [\"Question 1?\", \"Question 2?\", \"Question 3?\"] } ### Chat History: <chat_history> USER: My cat’s name is ASSISTANT: cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh \"# # # Task: Generate 1-3 broad tags categorizing the main themes of the chat history, along with 1-3 more specific subtopic tags. # # # Guidelines: - Start with high-level domains (e.g. Science, Technology, Philosophy, Arts, Politics, Business, Health, Sports, Entertainment, Education) - Consider including relevant subfields/subdomains if they are strongly represented throughout the conversation - If content is too short (less than 3 messages) or too diverse, use only [\\"General\\"] - Use the chat's primary language; default to English if multilingual - Prioritize accuracy over specificity # # # Output: JSON frmat:{ \"gs\\": [a1\" \"a2\" \\"ag3\\" # htHsoy <ca_hitry>UE:My cat’mSTANTrmd aftthini'taew_ength' hstdba_arra_e_egth./u_m_l. 1 Abored PT MDLGU -eie$LAADVC} $LAMA_toyTmaF2B32gS 1. 1 50 2. ��Sparky” and I like to play chess </chat_history>" 12 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf tSavorite 1.5 1024 50 0.9 5 12288 0.0
   13  trash
   14  trash
   15  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "### Task: Generate a concise, 3-5 word title with an emoji summarizing the chat history. ### Guidelines: - The title should clearly represent the main theme or subject of the conversation. - Use emojis that enhance understanding of the topic, but avoid quotation marks or special formatting. - Write the title in the chat's primary language; default to English if multilingual. - Prioritize accuracy over excessive creativity; keep it clear and simple. - Your entire response must consist solely of the JSON object, without any introductory or concluding text. - The output must be a single, raw JSON object, without any markdown code fences or other encapsulating text. - Ensure no conversational text, affirmations, or explanations precede or follow the raw JSON output, as this will cause direct parsing failure. ### Output: JSON format: { \"title\": \"your concise title here\" } ### Examples: - { \"title\": \"📉 Stock Market Trends\" }, - { \"title\": \"🍪 Perfect Chocolate Chip Recipe\" }, - { \"title\": \"Evolution of Music Streaming\" }, - { \"title\": \"Remote Work Productivity Tips\" }, - { \"title\": \"Artificial Intelligence in Healthcare\" }, - { \"title\": \"🎮 Video Game Development Insights\" } ### Chat History: <chat_history> USER: My cat’s name is ASSISTANT: cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh \"# # # Task: Generate 1-3 broad tags categorizing the main themes of the chat history, along with 1-3 more specific subtopic tags. # # # Guidelines: - Start with high-level domains (e.g. Science, Technology, Philosophy, Arts, Politics, Business, Health, Sports, Entertainment, Education) - Consider including relevant subfields/subdomains if they are strongly represented throughout the conversation - If content is too short (less than 3 messages) or too diverse, use only [\\"General\\"] - Use the chat's primary language; default to English if multilingual - Prioritize accuracy over specificity # # # Output: JSON frmat:{ \"gs\\": [a1\" \"a2\" \\"ag3\\" # htHsoy <ca_hitry>UE:My cat’mSTANTrmd aftthini'taew_ength' hstdba_arra_e_egth./u_m_l. 1 Abored PT MDLGU -eie$LAADVC} $LAMA_toyTmaF2B32gS 1. 1 50 2. ��Sparky” and I like to play chess </chat_history>" 12 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf tSavorite 1.5 1024 50 0.9 5 12288 0.0
   16  trash
   17  trash
   18  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "### Task: Generate 1-3 broad tags categorizing the main themes of the chat history, along with 1-3 more specific subtopic tags. ### Guidelines: - Start with high-level domains (e.g. Science, Technology, Philosophy, Arts, Politics, Business, Health, Sports, Entertainment, Education) - Consider including relevant subfields/subdomains if they are strongly represented throughout the conversation - If content is too short (less than 3 messages) or too diverse, use only [\"General\"] - Use the chat's primary language; default to English if multilingual - Prioritize accuracy over specificity ### Output: JSON format: { \"tags\": [\"tag1\", \"tag2\", \"tag3\"] } ### Chat History: <chat_history> USER: My cat’s name is ASSISTANT: cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh \"# # # Task: Generate 1-3 broad tags categorizing the main themes of the chat history, along with 1-3 more specific subtopic tags. # # # Guidelines: - Start with high-level domains (e.g. Science, Technology, Philosophy, Arts, Politics, Business, Health, Sports, Entertainment, Education) - Consider including relevant subfields/subdomains if they are strongly represented throughout the conversation - If content is too short (less than 3 messages) or too diverse, use only [\\"General\\"] - Use the chat's primary language; default to English if multilingual - Prioritize accuracy over specificity # # # Output: JSON frmat:{ \"gs\\": [a1\" \"a2\" \\"ag3\\" # htHsoy <ca_hitry>UE:My cat’mSTANTrmd aftthini'taew_ength' hstdba_arra_e_egth./u_m_l. 1 Abored PT MDLGU -eie$LAADVC} $LAMA_toyTmaF2B32gS 1. 1 50 2. ��Sparky” and I like to play chess </chat_history>" 12 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf tSavorite 1.5 1024 50 0.9 5 12288 0.0
   19  history
root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv33_07_17_2025/bin# 

The screen capture is as follows though note because this if FPGA2 it is crashing when running
<img width="1865" height="1225" alt="Screenshot 2025-07-28 163805" src="https://github.com/user-attachments/assets/51ae08b6-bd7b-4969-b7d9-504a8dff9e4e" />
