### PR TITLE
@FIR-850: Make default target show up and change target to Target

### DIFF
--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -14,7 +14,7 @@
 
 	const defaultParams = {
 		// Advanced
-		target: null,
+		target: 'native',
 		stream_response: null, // Set stream responses for this model individually
 		function_calling: null,
 		seed: null,
@@ -98,7 +98,7 @@
 			>
 			<div class="flex w-full justify-between">
 			<div class="self-center text-xs font-medium">
-					{$i18n.t('target')}
+					{$i18n.t('Target')}
 			</div>
 				<select
 					class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden bg-white text-black dark:bg-gray-800 dark:text-white"

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -65,7 +65,7 @@
 		mirostat_eta: null,
 		mirostat_tau: null,
 		top_k: null,
-		target: null,
+		target: 'native',
 		top_p: null,
 		min_p: null,
 		stop: null,


### PR DESCRIPTION
This change renames "target" as "Target" and makes "Native" default to be displayed.

the test results are as follows
<img width="1317" height="566" alt="Screenshot 2025-07-29 083752" src="https://github.com/user-attachments/assets/00937beb-2980-43ba-b31d-601bccace52b" />
<img width="1331" height="660" alt="Screenshot 2025-07-29 083816" src="https://github.com/user-attachments/assets/8b2d5053-e647-458d-a82a-0cd7ce0c2414" />
