### PR TITLE
@FIR-851: Increase the width and depth of profile tooltip

### DIFF
--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -1186,7 +1186,7 @@
 								{#if message.usage}
 									<Tooltip
 										content={message.usage
-											? `<pre>${sanitizeResponseContent(
+											? `<div style="max-width:900px; max-height:600px; overflow:auto;">${sanitizeResponseContent(
 													JSON.stringify(message.usage, null, 2)
 														.replace(/"([^(")"]+)":/g, '$1:')
 														.slice(1, -1)
@@ -1194,7 +1194,7 @@
 														.map((line) => line.slice(2))
 														.map((line) => (line.endsWith(',') ? line.slice(0, -1) : line))
 														.join('\n')
-												)}</pre>`
+												)}</duv>`
 											: ''}
 										placement="bottom"
 									>


### PR DESCRIPTION
This change increases the depth and width of rofile tool tip The width is increased to 900px and depth is increased to 600px

The test results are as follows

<img width="3804" height="1924" alt="Screenshot 2025-07-29 112700" src="https://github.com/user-attachments/assets/c6c2194b-fdf9-43c9-94a6-98465d623a1c" />
