### PR TITLE
Stabilization of file-transfer

### DIFF
--- a/backend/open_webui/routers/flaskIfc/copy2fpga-x86.sh
+++ b/backend/open_webui/routers/flaskIfc/copy2fpga-x86.sh
@@ -6,4 +6,5 @@
 #echo "  Inside copy2fpga-x86.sh "
 #sudo ./copy2fpga-setup.sh
 echo "sudo ./copy2fpga-x86 $1"
+sleep 5
 sudo ./copy2fpga-x86 $1

--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -206,14 +206,18 @@ def actual_transfer(file):
                      job_status["running"] = False
             thread = threading.Thread(target=scriptRecvFromHost)
             job_status = {"running": True, "result": "", "thread": thread}
-            thread.start()
             
             time.sleep(1) 
+
             file.save(os.path.join(app.config['UPLOAD_FOLDER'], filename))
-            process = subprocess.Popen(["./copy2fpga-x86.sh", filename], text=True)  
-            process.wait(timeout=5000)
-            print("Starting copy2fpga-x86 and sending file..." )
-            time.sleep(1) 
+
+            time.sleep(1)
+            
+            process = subprocess.Popen(["./copy2fpga-x86.sh", filename], text=True)
+            
+            thread.start()
+            
+            thread.join()
             
             
 
@@ -234,9 +238,16 @@ def receive_pull_model():
         path = "/usr/share/ollama/.ollama/models/blobs/" + data['actual_name']
     else:
         return "No valid filepath found"
+    
+    time.sleep(1)
 
     file_obj = open(path, "rb")
+    
+    time.sleep(1)
+
     upload = FileStorage(stream=file_obj, filename=data['actual_name'], content_type="application/octet-stream")
+
+    time.sleep(1)
 
     actual_transfer(upload)
     
@@ -247,6 +258,8 @@ def receive_pull_model():
     time.sleep(1)
 
     read_cmd_from_serial(port,baudrate,f"cd {destn_path}; ls -lt")
+
+    time.sleep(1)
 
     return manual_response(content="File Download Done",thinking="File Download Done",), 200
 


### PR DESCRIPTION
Hi everyone, I know this wasn't the best use of time but I just wanted to make file-transfer more stable since even the 92 MB file was not working (1 in 5 chance of actually transferring properly). I mainly added a lot of sleeps and reordered the script executions a bit to make it sync better. I will have pictures but for context, I was able to transfer a 92 MB file onto the target 4 times in a row and each time it was the correct sha number (9fb5) (Meera will understand this number) 

PROOF:

root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# md5sum smollm\:135m 
aa5aa53262b2988e362e5c31e2cf9fb5  smollm:135m <-----------------------------------CORRECT ATTEMPT #1
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# ls -l
-rw-r--r--    1 root     root     4400979520 Mar  9 12:44 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
lrwxrwxrwx    1 root     root            34 Mar  9 12:51 TinyLlama:1.1b -> Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root     1321082688 Mar  9 12:39 llama3.2:1b
-rw-r--r--    1 root     root      91727296 Mar  9 12:36 smollm:135m
-rw-r--r--    1 root     root      10007808 Mar  9 12:46 tinyllama-vo-5m-para.gguf
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# mv smollm:135m reference
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# ls -l
-rw-r--r--    1 root     root     4400979520 Mar  9 12:44 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
lrwxrwxrwx    1 root     root            34 Mar  9 12:51 TinyLlama:1.1b -> Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root     1321082688 Mar  9 12:39 llama3.2:1b
-rw-r--r--    1 root     root      91727296 Mar  9 12:36 reference
-rw-r--r--    1 root     root      10007808 Mar  9 12:46 tinyllama-vo-5m-para.gguf
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# md5sum reference
aa5aa53262b2988e362e5c31e2cf9fb5  reference
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
Terminating...
Thanks for using picocom
lewislui@fpga3:~$ sudo picocom /dev/ttyUSB3 -b 921600
picocom v3.1

port is        : /dev/ttyUSB3
flowcontrol    : none
baudrate is    : 921600
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
hangup is      : no
nolock is      : no
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        : 
omap is        : 
emap is        : crcrlf,delbs,
logfile is     : none
initstring     : none
exit_after is  : not set
exit is        : no

Type [C-a] [C-h] to see available commands
Terminal ready

root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# md5sum smollm\:135m 
aa5aa53262b2988e362e5c31e2cf9fb5  smollm:135m   <-----------------------------------CORRECT ATTEMPT #2
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
Terminating...
Thanks for using picocom
lewislui@fpga3:~$ sudo picocom /dev/ttyUSB3 -b 921600
picocom v3.1

port is        : /dev/ttyUSB3
flowcontrol    : none
baudrate is    : 921600
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
hangup is      : no
nolock is      : no
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        : 
omap is        : 
emap is        : crcrlf,delbs,
logfile is     : none
initstring     : none
exit_after is  : not set
exit is        : no

Type [C-a] [C-h] to see available commands
Terminal ready

root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# md5sum smollm\:135m 
aa5aa53262b2988e362e5c31e2cf9fb5  smollm:135m    <-----------------------------------CORRECT ATTEMPT #3
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
Terminating...
Thanks for using picocom
lewislui@fpga3:~$ sudo picocom /dev/ttyUSB3 -b 921600
picocom v3.1

port is        : /dev/ttyUSB3
flowcontrol    : none
baudrate is    : 921600
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
hangup is      : no
nolock is      : no
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        : 
omap is        : 
emap is        : crcrlf,delbs,
logfile is     : none
initstring     : none
exit_after is  : not set
exit is        : no

Type [C-a] [C-h] to see available commands
Terminal ready

root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# md5sum smollm\:135m 
aa5aa53262b2988e362e5c31e2cf9fb5  smollm:135m   <-----------------------------------CORRECT ATTEMPT #4
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
