### PR TITLE
@FIR-857: Fixed the string checks for txe-restart TXE endpoint

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -322,7 +322,7 @@ def internal_restart_txe():
     try:
         for line in process.stdout:
             print("HOST:" + line)
-            if "Global Reset exercised" in line:
+            if "Global Reset exercised" in line or "release chip from reset called" in line:
                 time.sleep(2)
                 os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                 break

--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -322,7 +322,7 @@ def internal_restart_txe():
     try:
         for line in process.stdout:
             print("HOST:" + line)
-            if "Global Reset exercised" in line or "release chip from reset called" in line:
+            if any(phrase in line for phrase in ["Global Reset exercised", "release chip from reset called"]):
                 time.sleep(2)
                 os.killpg(os.getpgid(process.pid), signal.SIGTERM)
                 break


### PR DESCRIPTION
The txe-restart endpoint was not working after make all as the make juart output has changed. The change adds the string to look for based on the new output.

The test results are as below and FPGA2 also works from Open-WebUI now.
<img width="1357" height="682" alt="Screenshot 2025-07-31 205849" src="https://github.com/user-attachments/assets/c7adfb86-a174-49eb-8801-3b0355c1959d" />
