### PR TITLE
@FIR-879: Reflect target on all pages and remove expansion for restart

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -13,9 +13,6 @@ import serial_script
 import re
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
-import tkinter as tk
-from tkinter import messagebox
-
 
 
 
@@ -475,7 +472,6 @@ def manual_response(status="success",model="ollama",content=None,thinking=None,t
                 },
             "data": {
                 "some_key": some_key,
-                "profile_data": profile_data
                 },
             "done": True #This is to indicate that we are one command at a time, not interactive
             }

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { createEventDispatcher, getContext } from 'svelte';
+	import { createEventDispatcher, getContext, onMount } from 'svelte';
 	const dispatch = createEventDispatcher();
 	const i18n = getContext('i18n');
 
@@ -13,6 +13,11 @@
 	export let models = [];
 	export let chatFiles = [];
 	export let params = {};
+
+       onMount(async () => {
+                params = { ...params, ...$settings.params };
+                params.stop = $settings?.params?.stop ? ($settings?.params?.stop ?? []).join(',') : null;
+        });
 
 	let showValves = false;
 </script>
@@ -164,29 +169,28 @@
 
                 {#if ($user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true)) && (params.target === 'cpu' || params.target === 'opu') }
                         <hr class="border-gray-50 dark:border-gray-850 my-3" />
+                        <div class="mt-2 space-y-3 pr-1.5">
+                                <div class="flex justify-between items-center text-sm">
+                                        <div class="  font-medium">{$i18n.t('Restart Opu')}</div>
 
-			<Collapsible title={$i18n.t('Restart Opu')} open={false} buttonClassName="w-full">
-				<div class="" slot="content">
-					<!-- Main Restart Now button -->
-					<button
-						disabled={$isRestarting}
-						class={
-							'w-auto text-sm px-2 py-1 rounded-md transition-colors duration-200' +
-							($settings.highContrastMode?
-							 ' border-2 border-gray-300 dark : border-gray-700 bg-gray-50 dark:bg-gray-850 text-gray-900 dark:text-gray-100 ' +
-							($isRestarting ? 'opacity-50 cursor-not-allowed' :
-							'hover:bg-blue-100 dark:hover:bg-blue-900') : ' bg-blue-600 text-white ' +
-							($isRestarting ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700 dark:bg-blue-600'))
-						}
-						on:click={() => {
-							restartOpu(); // Restart logic
-							}
-						}
-						>
-						{$isRestarting ? $i18n.t('Restarting...') : $i18n.t('Restart Now')}
-					</button>
-				</div>
-			</Collapsible>
+                                <button
+                                        disabled={$isRestarting}
+                                        class={
+                                                'w-auto text-sm px-2 py-1 rounded-md transition-colors duration-200' +
+                                                ($settings.highContrastMode ?
+                                                ' border-2 border-gray-300 dark : border-gray-700 bg-gray-50 dark:bg-gray-850 text-gray-900 dark:text-gray-100 ' +
+                                                ($isRestarting ? 'opacity-50 cursor-not-allowed' :
+                                                'hover:bg-blue-100 dark:hover:bg-blue-900') : ' bg-blue-600 text-white ' +
+                                                ($isRestarting ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700 dark:bg-blue-600'))
+                                        }
+                                        on:click={() => {
+                                                restartOpu(); // Restart logic
+                                                }
+                                        }>{$isRestarting ? $i18n.t('OPU Restarting...') : $i18n.t('Restart OPU Now')}
+                                </button>
+                                </div>
+                        </div>
+
 		{/if}
 
 		{#if $user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true)}

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -314,7 +314,7 @@
 					on:click={() => {
 						restartOpu(); // Restart logic
 						}
-					}>{$isRestarting ? $i18n.t('Restarting...') : $i18n.t('Restart Now')}
+					}>{$isRestarting ? $i18n.t('OPU Restarting...') : $i18n.t('Restart OPU Now')}
 				</button>
 				</div>
                         </div>


### PR DESCRIPTION
The change has following
1. Make OPU restart a top level button without expansion when OPU/CPU is selected as target
2. Make OPU or CPU target selection updated on all pages when saved
3. Remove the requirement for not used modules in flaskIfc.py
4. Remove duplicate profile data being passed in json by flaskIfc

The results are as following
<img width="1430" height="834" alt="Screenshot 2025-08-05 131259" src="https://github.com/user-attachments/assets/d36d0b70-8811-44b2-95aa-268124722a75" />
<img width="1433" height="833" alt="Screenshot 2025-08-05 131314" src="https://github.com/user-attachments/assets/1576354a-5a0b-47f4-a227-9f06a05a9fd2" />
<img width="1433" height="841" alt="Screenshot 2025-08-05 131346" src="https://github.com/user-attachments/assets/26fd9348-77f3-419b-949a-d75c041c40b0" />
<img width="1431" height="836" alt="Screenshot 2025-08-05 131403" src="https://github.com/user-attachments/assets/fcc97ca5-76bc-41ea-8d59-fbb482b99a7d" />
<img width="1432" height="834" alt="Screenshot 2025-08-05 131431" src="https://github.com/user-attachments/assets/e1ee6f07-f8bb-40e8-8874-0bea08e104d2" />
<img width="1419" height="836" alt="Screenshot 2025-08-05 131453" src="https://github.com/user-attachments/assets/4b0ca610-cd3e-481c-a4be-b982e0d272b3" />
<img width="1428" height="837" alt="Screenshot 2025-08-05 131514" src="https://github.com/user-attachments/assets/90841fd0-c969-4816-a3c9-c6d0ce913ff8" />
