### PR TITLE
@FIR-881: Add confirmation before aborting a task

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -83,7 +83,6 @@
 	import Messages from '$lib/components/chat/Messages.svelte';
 	import Navbar from '$lib/components/chat/Navbar.svelte';
 	import ChatControls from './ChatControls.svelte';
-	import {abortTaskOpu} from './Controls/Controls.svelte';
 	import EventConfirmDialog from '../common/ConfirmDialog.svelte';
 	import Placeholder from './Placeholder.svelte';
 	import NotificationToast from '../NotificationToast.svelte';
@@ -1836,11 +1835,6 @@
 	};
 
 	const stopResponse = async () => {
-		if (($user?.role === 'admin' || ($user?.permissions.chat?.controls ?? true)) && (params.target === 'cpu' || params.target === 'opu')) {
-			const res = await abortTaskOpu().catch((error) => {
-				toast.error(`${error}`);
-			});
-		}
 		if (taskIds) {
 			for (const taskId of taskIds) {
 				const res = await stopTask(localStorage.token, taskId).catch((error) => {

--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -104,6 +104,13 @@
 			restartOpu(); // Restart logic
 		}
 	}
+        export async function handleAbortClick() {
+                const confirmed = window.confirm("Are you sure you want to abort the query?");
+                if (confirmed) {
+                        abortTaskOpu(); // Abort logic
+                }
+        }
+
 </script>
 
 <div class=" dark:text-white">

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -12,7 +12,7 @@
 	import { v4 as uuidv4 } from 'uuid';
 	import { createPicker, getAuthToken } from '$lib/utils/google-drive-picker';
 	import { pickAndDownloadFile } from '$lib/utils/onedrive-file-picker';
-	import { abortTaskOpu} from './Controls/Controls.svelte';
+	import { handleAbortClick } from './Controls/Controls.svelte';
 	import { onMount, tick, getContext, createEventDispatcher, onDestroy } from 'svelte';
 	const dispatch = createEventDispatcher();
 
@@ -1825,7 +1825,7 @@
 													<button
 														class="bg-white hover:bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-800 transition rounded-full p-1.5"
 														on:click={() => {
-															abortTaskOpu();
+															handleAbortClick();
 															stopResponse();
 														}}
 													>


### PR DESCRIPTION
This change has following
1. Add a confirmation pop-up when abort is instantiated
2. Remove the task which is triggering abort twice
3. Remove abortTaskOpu using used and use handleAbortClick instead

The test results are below

<img width="1763" height="1085" alt="Screenshot 2025-08-06 124043" src="https://github.com/user-attachments/assets/b8d6beb3-a048-473d-a86a-bc0f0687d7d6" />
<img width="1778" height="1092" alt="Screenshot 2025-08-06 124057" src="https://github.com/user-attachments/assets/e51e5983-75fe-4deb-9e34-7d7cc48eae09" />

TXE Manager cleanup and restart successful.
Response:
 {"status": "success", "model": "ollama", "message": {"content": null, "thinking": "Abort Task", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "user": {"name": "Alice", "id": "12345", "email": "alice@example.com", "role": "admin"}, "data": {"some_key": "some_value"}, "done": true} 

127.0.0.1 - - [06/Aug/2025 12:40:48] "POST /api/abort-task HTTP/1.1" 200 -
/proj/work/atrivedi/workspace/08_06_2025/open-webui
atrivedi@fpga1:/proj/work/atrivedi/workspace/08_06_2025/open-webui$ 
