### PR TITLE
@FIR-898: Move restart OPU to settings page & put abortTask instead

### DIFF
--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -9,7 +9,7 @@
 	import FileItem from '$lib/components/common/FileItem.svelte';
 	import Collapsible from '$lib/components/common/Collapsible.svelte';
 
-	import { user, settings, isRestarting } from '$lib/stores';
+	import { user, settings, isRestarting, isAborting } from '$lib/stores';
 	export let models = [];
 	export let chatFiles = [];
 	export let params = {};
@@ -80,6 +80,7 @@
                 }
         }
 	export async function abortTaskOpu() {
+		isAborting.set(true);
                 try {
                         const response = await fetch('/ollama/api/aborttaskopu', {
                                 method: 'POST',
@@ -97,6 +98,9 @@
                         alert('Something went wrong while aborting task on OPU.');
                         return null;
                 }
+		finally {
+			isAborting.set(false);
+		}
         }
 	export async function handleRestartClick() {
 		const confirmed = window.confirm("Are you sure you want to restart the OPU?");
@@ -184,7 +188,7 @@
                         <hr class="border-gray-50 dark:border-gray-850 my-3" />
                         <div class="mt-2 space-y-3 pr-1.5">
                                 <div class="flex justify-between items-center text-sm">
-                                        <div class="  font-medium">{$i18n.t('Restart Opu')}</div>
+                                        <div class="  font-medium">{$i18n.t('Abort Job')}</div>
 
                                 <button
                                         disabled={$isRestarting}
@@ -193,13 +197,13 @@
                                                 ($settings.highContrastMode ?
                                                 ' border-2 border-gray-300 dark : border-gray-700 bg-gray-50 dark:bg-gray-850 text-gray-900 dark:text-gray-100 ' +
                                                 ($isRestarting ? 'opacity-50 cursor-not-allowed' :
-                                                'hover:bg-red-100 dark:hover:bg-red-900') : ' bg-red-600 text-white ' +
-                                                ($isRestarting ? 'opacity-50 cursor-not-allowed' : 'hover:bg-red-700 dark:bg-red-600'))
+                                                'hover:bg-blue-100 dark:hover:bg-blue-900') : ' bg-blue-600 text-white ' +
+                                                ($isRestarting ? 'opacity-50 cursor-not-allowed' : 'hover:bg-blue-700 dark:bg-blue-600'))
                                         }
                                         on:click={() => {
-						handleRestartClick();  //Pop up confirmation dialog and instantiate restart once confirmed
+						handleAbortClick();  //Pop up confirmation dialog and instantiate restart once confirmed
 						}
-                                        }>{$isRestarting ? $i18n.t('OPU Restarting...') : $i18n.t('Restart OPU Now')}
+                                        }>{$isAborting ? $i18n.t('Job being aborted...') : $i18n.t('Abort Job Now')}
                                 </button>
                                 </div>
                         </div>

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -89,6 +89,7 @@ export const isLastActiveTab = writable(true);
 export const playingNotificationSound = writable(false);
 
 export let isRestarting = writable(false);
+export let isAborting = writable(false);
 
 export type Model = OpenAIModel | OllamaModel;
 


### PR DESCRIPTION
The change has following
1. Change restartOpu to abortTask on chats page
2. Change color of abortTask to blue and only allow abort Task once till the abort is not complete

The test results are as follows:
127.0.0.1 - - [16/Aug/2025 10:46:19] "POST /api/chat HTTP/1.1" 200 -
Request: {'model': 'llama3.2:1B-1.2B-F32', 'messages': [{'role': 'user', 'content': '### Task:\nGenerate 1-3 broad tags categorizing the main themes of the chat history, along with 1-3 more specific subtopic tags.\n\n### Guidelines:\n- Start with high-level domains (e.g. Science, Technology, Philosophy, Arts, Politics, Business, Health, Sports, Entertainment, Education)\n- Consider including relevant subfields/subdomains if they are strongly represented throughout the conversation\n- If content is too short (less than 3 messages) or too diverse, use only ["General"]\n- Use the chat\'s primary language; default to English if multilingual\n- Prioritize accuracy over specificity\n\n### Output:\nJSON format: { "tags": ["tag1", "tag2", "tag3"] }\n\n### Chat History:\n<chat_history>\nUSER: My dog is\nASSISTANT: \n</chat_history>'}], 'stream': False}
Response:
 {"status": "success", "model": "ollama", "message": {"content": "Result Empty: Desired phrase not found in the response.", "thinking": "Result Empty: Desired phrase not found in the response.", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 

127.0.0.1 - - [16/Aug/2025 10:46:19] "POST /api/chat HTTP/1.1" 200 -
TXE Manager cleanup and restart successful.
Response:
 {"status": "success", "model": "ollama", "message": {"content": null, "thinking": "Abort Task", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 

127.0.0.1 - - [16/Aug/2025 10:46:19] "POST /api/abort-task HTTP/1.1" 200 -

<img width="1572" height="1394" alt="Screenshot 2025-08-16 104529" src="https://github.com/user-attachments/assets/18cb1e1d-4c93-48fe-ad78-d535aa78aec3" />
<img width="1573" height="1406" alt="Screenshot 2025-08-16 104554" src="https://github.com/user-attachments/assets/30130d88-f21e-4ea2-a6c2-59732ad0ce3b" />
<img width="1580" height="1397" alt="Screenshot 2025-08-16 104618" src="https://github.com/user-attachments/assets/9bf54c4b-4712-4092-85d8-50579c1e549a" />
<img width="1574" height="1395" alt="Screenshot 2025-08-16 104635" src="https://github.com/user-attachments/assets/e3c91930-11b3-4604-a0d1-a74a6543a23d" />
<img width="1570" height="1402" alt="Screenshot 2025-08-16 104653" src="https://github.com/user-attachments/assets/b8587273-7eea-40a7-8d3c-e9bacf176cbc" />
