### PR TITLE
@FIR-902: Increase the model run timeout to 4 hours & parse profile o/p

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -35,6 +35,8 @@ DEFAULT_LAST_N = 5
 DEFAULT_CONTEXT_LENGTH = 12288
 DEFAULT_TEMP = 0.0
 
+DEFAULT_MODEL_COMMAND_RUN_TIMEOUT = 14400
+
 parameters = {    'target': 'opu',
                   'num_predict': DEFAULT_TOKEN,
                   'repeat_penalty': DEFAULT_REPEAT_PENALTY,
@@ -702,17 +704,25 @@ def chats():
         try:
             is_job_running()
             job_status["running"] = True
-            result = serial_script.send_serial_command(port,baudrate,command)
+            result = serial_script.send_serial_command(port,baudrate,command, timeout=DEFAULT_MODEL_COMMAND_RUN_TIMEOUT)
             if result:
                 response_text = result
-                start_phrase = "llama_perf_sampler_print: "
-                if start_phrase in response_text:
-                    filtered_text = response_text.split(start_phrase, 1)[0] # Split once and drop the second part
-                    formatted_text = response_text.split(start_phrase, 1)[1]
+                start_phrases = [
+                    "llama_perf_sampler_print: ",
+                    "GGML Tsavorite Profiling Results:"
+                ]
+
+                matched_phrase = next((phrase for phrase in start_phrases if phrase in response_text), None)
+
+                if matched_phrase:
+                    filtered_text = response_text.split(matched_phrase, 1)[0]
+                    formatted_text = response_text.split(matched_phrase, 1)[1]
                 else:
                     filtered_text = result
+                    formatted_text = None
             else:
                 filtered_text = "Result Empty: Desired phrase not found in the response."
+                formatted_text = None  # Or None, depending on your use case
                 job_status["result"] = filtered_text
 
             job_status["running"] = False
@@ -796,13 +806,18 @@ def chat():
         try:
             is_job_running()
             job_status["running"] = True
-            result = serial_script.send_serial_command(port,baudrate,command)
+            result = serial_script.send_serial_command(port,baudrate,command, timeout=DEFAULT_MODEL_COMMAND_RUN_TIMEOUT)
             if result:
                 response_text = result
-                start_phrase = "llama_perf_sampler_print: "
-                if start_phrase in response_text:
-                    filtered_text = response_text.split(start_phrase, 1)[0] # Split once and drop the second part
-                    formatted_text = response_text.split(start_phrase, 1)[1]
+                start_phrases = [
+                    "llama_perf_sampler_print: ",
+                    "GGML Tsavorite Profiling Results:"
+                ]
+                matched_phrase = next((phrase for phrase in start_phrases if phrase in response_text), None)
+
+                if matched_phrase:
+                    filtered_text = response_text.split(matched_phrase, 1)[0]
+                    formatted_text = response_text.split(matched_phrase, 1)[1]
                 else:
                     filtered_text = result
                     formatted_text = None

--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -81,6 +81,7 @@ DEFAULT_FLASK_URL = "http://localhost:5001"
 
 async def send_get_request(url, key=None, user: UserModel = None):
     timeout = aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT_MODEL_LIST)
+    print("Get Request Url:", url)
     try:
         async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
             async with session.get(
@@ -133,6 +134,7 @@ async def send_post_request(
         session = aiohttp.ClientSession(
             trust_env=True, timeout=aiohttp.ClientTimeout(total=AIOHTTP_CLIENT_TIMEOUT)
         )
+        print("Post Request Url:", url, "Payload:", payload)
 
         r = await session.post(
             url,


### PR DESCRIPTION
The changes does following
1. This change increases the command run time to 4 hours instead of 2
2. The change also looks for not just llama_print but the GGML Profile text to filter out the profile output from the generated text

Earlier the commands were timing out in 2 hours so with RAG workflow the output was not complete.

The test results are as follows
127.0.0.1 - - [19/Aug/2025 08:08:45] "POST /api/restart-txe HTTP/1.1" 200 -
Request: {'model': 'llama3.2:1B-1.2B-F32', 'messages': [{'role': 'user', 'content': '### Task:\nAnalyze the chat history to determine the necessity of generating search queries, in the given language. By default, **prioritize generating 1-3 broad and relevant search queries** unless it is absolutely certain that no additional information is required. The aim is to retrieve comprehensive, updated, and valuable information even with minimal uncertainty. If no search is unequivocally needed, return an empty list.\n\n### Guidelines:\n- Respond **EXCLUSIVELY** with a JSON object. Any form of extra commentary, explanation, or additional text is strictly prohibited.\n- When generating search queries, respond in the format: { "queries": ["query1", "query2"] }, ensuring each query is distinct, concise, and relevant to the topic.\n- If and only if it is entirely certain that no useful results can be retrieved by a search, return: { "queries": [] }.\n- Err on the side of suggesting search queries if there is **any chance** they might provide useful or updated information.\n- Be concise and focused on composing high-quality search queries, avoiding unnecessary elaboration, commentary, or assumptions.\n- Today\'s date is: 2025-08-19.\n- Always prioritize providing actionable and broad queries that maximize informational coverage.\n\n### Output:\nStrictly return in JSON format: \n{\n  "queries": ["query1", "query2"]\n}\n\n### Chat History:\n<chat_history>\nUSER: Ultraethernet is\n</chat_history>\n'}], 'stream': False}
Response:
 {"status": "success", "model": "ollama", "message": {"content": "\" 130 llama3.2:1B-1.2B-F32 tSavor\rrite 1.5 1024 50 0.9 5 12288 0.0\nUSER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm\n\n\n\n", "thinking": " <chat_\r_history> USER: Ultraethernet is </chat_history>\" 130 llama3.2:1B-1.2B-F32 tSavor\rrite 1.5 1024 50 0.9 5 12288 0.0\nUSER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm sorry, but the chat history is not available. USER: I'm\n\n\n\n", "tool_calls": null, "openai_tool_calls": null, "meta": "   sampling time =   10556.03 ms /   424 runs   (   24.90 ms per token,    40.17 tokens per second)llama_perf_context_print:        load time = 2719861.48 ms\nllama_perf_context_print: prompt eval time = 2692830.29 ms /   294 tokens ( 9159.29 ms per token,     0.11 tokens per second)\nllama_perf_context_print:        eval time = 4674320.70 ms /   129 runs   (36235.04 ms per token,     0.03 tokens per second)\nllama_perf_context_print:       total time = 7406473.66 ms /   423 tokens\n\n=== GGML Perf Summary ===\nOp              :    Runs        Total us            Avg us\nADD             :    4160       267864009          64390.39\n[TSAVORITE ] :    4160       267864009          64390.39\nMUL             :    6370       750019200         117742.42\n[TSAVORITE ] :    6370       750019200         117742.42\nRMS_NORM        :   13799         1598137            115.82\n[CPU       ] :   13799         1598137            115.82\nMUL_MAT         :   73976     12550166525         169651.87\n[CPU       ] :   73976     12550166525         169651.87\nCPY             :   14868      1254954577          84406.41\n[CPU       ] :   14868      1254954577          84406.41\nCONT            :    5624          189979             33.78\n[CPU       ] :    5624          189979             33.78\nRESHAPE         :   15787          181140             11.47\n[CPU       ] :   15787          181140             11.47\nVIEW            :   14172           23602              1.67\n[CPU       ] :   14172           23602              1.67\nPERMUTE         :   14126           32650              2.31\n[CPU       ] :   14126           32650              2.31\nTRANSPOSE       :    3487            9514              2.73\n[CPU       ] :    3487            9514              2.73\nGET_ROWS        :    1108          677549            611.51\n[CPU       ] :    1108          677549            611.51\nSOFT_MAX        :    6705        20089329           2996.17\n[CPU       ] :    6705        20089329           2996.17\nROPE            :   13469         1759053            130.60\n[CPU       ] :   13469         1759053            130.60\nUNARY           :    2080       498674711         239747.46\n[TSAVORITE ] :    2080       498674711         239747.46\n-> SILU        :    2080       498674711         239747.46\n\nGGML Tsavorite Profiling Results:\n------------------------------------------------------------------------------------------------------------------------\nCalls  Total(ms)    T/call    Self(ms)  Function\n------------------------------------------------------------------------------------------------------------------------\n1   139.6090  139.6090     34.8070  [1.89e-03%] [Thread] GGML Tsavorite\n1   104.8020  104.8020     84.7100  \u2514\u2500 [1.42e-03%] tsi::runtime::TsavRTFPGA::initialize\n1     8.6800    8.6800      8.6800    \u2514\u2500 [1.18e-04%] tsi::runtime::TsavRTFPGA::initializeQueues\n1     8.2240    8.2240      8.2240    \u2514\u2500 [1.11e-04%] tsi::runtime::TsavRT::initialize\n1     3.1880    3.1880      2.6840    \u2514\u2500 [4.32e-05%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand\n2     0.5040    0.2520      0.5040      \u2514\u2500 [6.83e-06%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06   4.27e+05    0.1706      0.0000  [ 5.78%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion\n2e+06   1.42e+07    5.6885    1.42e+07  \u2514\u2500 [192.62%] TXE 0 Idle\n1e+06   2.04e+05    0.1625    2.04e+05  \u2514\u2500 [ 2.77%] [ txe_mult ]\n8e+05   1.37e+05    0.1650    1.37e+05  \u2514\u2500 [ 1.85%] [ txe_silu ]\n4e+05 67363.7054    0.1626  67363.7054  \u2514\u2500 [9.12e-01%] [ txe_add ]\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06   2.25e+05    0.0898    1.99e+05  [ 3.04%] [Thread] tsi::runtime::TsavRT::finalizeCommandList\n2e+06 25655.6360    0.0103  25655.6360  \u2514\u2500 [3.48e-01%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06   3.72e+05    0.1488  62089.7240  [ 5.04%] [Thread] tsi::runtime::TsavRT::processResponses\n2e+06   3.10e+05    0.1240    3.10e+05  \u2514\u2500 [ 4.20%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1    63.8730   63.8730     49.2350  [8.65e-04%] [Thread] tsi::runtime::TsavRTFPGA::finalize\n1    14.6380   14.6380     14.6380  \u2514\u2500 [1.98e-04%] tsi::runtime::TsavRTFPGA::releaseTxes\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06 23856.1520    0.0095  23856.1520  [3.23e-01%] [Thread] tsi::runtime::TsavRT::allocate\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06   3.40e+05    0.1360    3.40e+05  [ 4.60%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06 83793.8960    0.0335  83793.8960  [ 1.13%] [Thread] tsi::runtime::TsavRT::addCommandToList\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06   1.81e+05    0.0725    1.81e+05  [ 2.45%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n2e+06 25266.1200    0.0101  25266.1200  [3.42e-01%] [Thread] tsi::runtime::TsavRT::deallocate\n========================================================================================================================\n-   7.38e+06    0.0000    7.38e+06  [100.00%] TOTAL\n========================================================================================================================\n\nCounter Metrics:\n------------------------------------------------------------------------------------------------------------------------\nMetric                                    Min            Max            Avg\n------------------------------------------------------------------------------------------------------------------------\nQueue_0_Occupancy                      0.0000         1.0000         0.9627\n------------------------------------------------------------------------------------------------------------------------\n\n"}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 
127.0.0.1 - - [19/Aug/2025 10:14:08] "POST /api/chat HTTP/1.1" 200 -
