### PR TITLE
@FIR-903: Fix auto  merge issue resulting in duplicate advanced Params

### DIFF
--- a/src/lib/components/chat/Controls/Controls.svelte
+++ b/src/lib/components/chat/Controls/Controls.svelte
@@ -222,43 +222,6 @@
 
 				<hr class="my-2 border-gray-50 dark:border-gray-700/10" />
 			{/if}
-
-			{#if $user?.role === 'admin' || ($user?.permissions.chat?.valves ?? true)}
-				<Collapsible bind:open={showValves} title={$i18n.t('Valves')} buttonClassName="w-full">
-					<div class="text-sm" slot="content">
-						<Valves show={showValves} />
-					</div>
-				</Collapsible>
-
-				<hr class="my-2 border-gray-50 dark:border-gray-700/10" />
-			{/if}
-
-			{#if $user?.role === 'admin' || ($user?.permissions.chat?.system_prompt ?? true)}
-				<Collapsible title={$i18n.t('System Prompt')} open={true} buttonClassName="w-full">
-					<div class="" slot="content">
-						<textarea
-							bind:value={params.system}
-							class="w-full text-xs outline-hidden resize-vertical {$settings.highContrastMode
-								? 'border-2 border-gray-300 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800 p-2.5'
-								: 'py-1.5 bg-transparent'}"
-							rows="4"
-							placeholder={$i18n.t('Enter system prompt')}
-						/>
-					</div>
-				</Collapsible>
-
-				<hr class="my-2 border-gray-50 dark:border-gray-700/10" />
-			{/if}
-
-			{#if $user?.role === 'admin' || ($user?.permissions.chat?.params ?? true)}
-				<Collapsible title={$i18n.t('Advanced Params')} open={true} buttonClassName="w-full">
-					<div class="text-sm mt-1.5" slot="content">
-						<div>
-							<AdvancedParams admin={$user?.role === 'admin'} custom={true} bind:params />
-						</div>
-					</div>
-				</Collapsible>
-			{/if}
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
This change removed the duplicate advanced params on Chat control menu

The test results are as follows
before the change

<img width="1425" height="830" alt="Screenshot 2025-08-19 130922" src="https://github.com/user-attachments/assets/d3abfd36-4ee6-40b2-a969-d9323b57b2a7" />

After the change
<img width="1434" height="832" alt="Screenshot 2025-08-19 131052" src="https://github.com/user-attachments/assets/3d47d5d1-6f3c-45d1-8d75-3729fb9d3893" />

