### PR TITLE
@FIR-904: Make changes to make OPU target as default

### DIFF
--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -14,7 +14,7 @@
 
 	const defaultParams = {
 		// Advanced
-		target: 'native',
+		target: 'opu',
 		stream_response: null, // Set stream responses for this model individually
 		stream_delta_chunk_size: null, // Set the chunk size for streaming responses
 		function_calling: null,
@@ -105,9 +105,9 @@
 					class="p-1 px-3 text-xs flex rounded-sm transition shrink-0 outline-hidden bg-white text-black dark:bg-gray-800 dark:text-white"
 					bind:value={params.target}
 				>
-					<option value="native">{$i18n.t('Native')}</option>
 					<option value="opu">{$i18n.t('OPU')}</option>
 					<option value="cpu">{$i18n.t('CPU')}</option>
+					<option value="native">{$i18n.t('Native')}</option>
 				</select>
 			</div>
 		</Tooltip>

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -66,7 +66,7 @@
 		mirostat_eta: null,
 		mirostat_tau: null,
 		top_k: null,
-		target: 'native',
+		target: 'opu',
 		top_p: null,
 		min_p: null,
 		stop: null,


### PR DESCRIPTION
This change makes OPU as default target 

The test results are as follows:
<img width="2024" height="1024" alt="Screenshot 2025-08-19 154838" src="https://github.com/user-attachments/assets/72428849-42ad-46ed-877d-11cc87b1ba45" />

