### PR TITLE
@FIR-910: Added endpoint to delete models from FPGA

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -409,6 +409,31 @@ def receive_pull_model():
       
     return manual_response(content="File Download Done",thinking="File Download Done", incoming_headers=incoming_headers), 200
 
+def denormalize_model_name(model_name):
+    if model_name.endswith(":latest"):
+        return model_name.split(":")[0]
+    return model_name
+
+
+@app.route('/api/opu-delete-model', methods=['GET', 'POST'])
+def opu_delete_model():
+    serial_script.pre_and_post_check(port,baudrate)
+    data = request.get_json()
+
+    incoming_headers = dict(request.headers)
+
+    try:
+        model_name = data['model_name']
+        print("model_name: ", model_name, "destn_path", destn_path)
+    except (TypeError, KeyError) as e:
+        return manual_response(content=f"Invalid JSON data: {e}",thinking=f"Invalid JSON data: {e}", incoming_headers=incoming_headers), 400
+
+    file_name = denormalize_model_name(data['model_name'])
+
+    read_cmd_from_serial(port,baudrate,f"cd {destn_path}; rm -fr {file_name} && find . -type d -empty | while read -r dir; do rmdir \"$dir\"; done")
+
+    return manual_response(content="Model deleted",thinking="Model deleted", incoming_headers=incoming_headers), 200
+
 
 @app.route('/upload-file', methods=['GET', 'POST'])
 def upload_file():


### PR DESCRIPTION
This change does following
1. Delete a model from the FPGA when a model is deleted in Ollama
2. If the model is hierarchical deletes all the empty directories

The test results are as follows
<img width="2140" height="1619" alt="Screenshot 2025-08-21 200314" src="https://github.com/user-attachments/assets/0eacef0b-b4d5-43e1-8950-b290e37d2ebb" />
<img width="2148" height="1634" alt="Screenshot 2025-08-21 200330" src="https://github.com/user-attachments/assets/9d860aef-43b4-4893-b6d9-532afd82bed3" />
<img width="2143" height="1629" alt="Screenshot 2025-08-21 200409" src="https://github.com/user-attachments/assets/1e863720-7ba8-4a37-bb9e-fa5c21ea8616" />
<img width="2143" height="1626" alt="Screenshot 2025-08-21 200439" src="https://github.com/user-attachments/assets/5e6b0b26-0fdb-4a8f-8e68-6594f8158d0e" />

Target log
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
/gguf/; ls -lt
-rw-r--r--    1 root     root     3012481120 Jul 11  2025 qwen3.gguf
-rw-r--r--    1 100023   100003   4951088896 Jul 11  2025 llama32-1b-instruct.gguf
-rw-r--r--    1 root     root     3012481120 Mar 10  2018 new-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar 10  2018 part-1Gac
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gaa
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gab
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-webui-d45
-rw-r--r--    1 root     root     397149152 Mar 10  2018 karar-test-ed8
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-test-d45
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 karar-test-Tinyllama-1.1B.gguf
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root      36806944 Mar 10  2018 gte-small.Q8_0.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 bge4.gguf
-rw-r--r--    1 root     root      42946355 Mar  9  2018 TinyLlama.tz
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte9.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte2.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 orecvd-gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte8.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte6.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte5.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 custom-model.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 gte7.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte3.gguf
drwxr-xr-x    3 root     root          4096 Mar  9 16:47 hf.co
-rw-r--r--    1 root     root     4951085024 Mar  9 16:19 Llama32-1b-sc.gguf
-rw-r--r--    1 root     root     3012481120 Mar  9 15:50 re-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar  9 15:48 part1-Gac
-rw-r--r--    1 root     root     1073741824 Mar  9 15:25 part1-Gaa
-rw-r--r--    1 root     root     4400979520 Mar  9 14:32 fpga1-Tinygguf
-rw-r--r--    1 root     root      36806944 Mar  9 14:11 my-gte-guuf
-rw-r--r--    1 root     root     4951085024 Mar  9 13:37 Llama3.2:1B-1.2B-F32
-rwxrwxrwx    1 root     root      10007808 Mar  9 13:27 tinyllama-vo-5m-para.gguf
-rw-r--r--    1 root     root     8132911200 Mar  9 13:13 qwen3_1_7b:latest
-rw-r--r--    1 root     root         10240 Mar  9 13:07 JUNE-19.tar
-rw-r--r--    1 root     root     174456832 Mar  9 12:56 root:latest
lrwxrwxrwx    1 root     root            20 Mar  9 12:42 llama3.2:1B-1.2B-F32 -> Llama3.2:1B-1.2B-F32
-rw-r--r--    1 root     root      10007808 Mar  9 12:36 MayKeye:latest
v/Maykeye_-_TinyLLama-v0-gguf si/proj/model-cache/gguf# ls -l hf.co/RichardErkhov
-rw-r--r--    1 root     root       4382976 Mar  9 16:47 hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
Terminating...
Thanks for using picocom
Terminal ready
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# ls- lt
-sh: ls-: command not found
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# ls -lt
-rw-r--r--    1 root     root     3012481120 Jul 11  2025 qwen3.gguf
-rw-r--r--    1 100023   100003   4951088896 Jul 11  2025 llama32-1b-instruct.gguf
-rw-r--r--    1 root     root     3012481120 Mar 10  2018 new-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar 10  2018 part-1Gac
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gaa
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gab
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-webui-d45
-rw-r--r--    1 root     root     397149152 Mar 10  2018 karar-test-ed8
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-test-d45
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 karar-test-Tinyllama-1.1B.gguf
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root      36806944 Mar 10  2018 gte-small.Q8_0.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 bge4.gguf
-rw-r--r--    1 root     root      42946355 Mar  9  2018 TinyLlama.tz
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte9.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte2.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 orecvd-gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte8.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte6.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte5.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 custom-model.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 gte7.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte3.gguf
drwxr-xr-x    2 root     root          4096 Mar  9 16:48 hf.co
-rw-r--r--    1 root     root     4951085024 Mar  9 16:19 Llama32-1b-sc.gguf
-rw-r--r--    1 root     root     3012481120 Mar  9 15:50 re-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar  9 15:48 part1-Gac
-rw-r--r--    1 root     root     1073741824 Mar  9 15:25 part1-Gaa
-rw-r--r--    1 root     root     4400979520 Mar  9 14:32 fpga1-Tinygguf
-rw-r--r--    1 root     root      36806944 Mar  9 14:11 my-gte-guuf
-rw-r--r--    1 root     root     4951085024 Mar  9 13:37 Llama3.2:1B-1.2B-F32
-rwxrwxrwx    1 root     root      10007808 Mar  9 13:27 tinyllama-vo-5m-para.gguf
-rw-r--r--    1 root     root     8132911200 Mar  9 13:13 qwen3_1_7b:latest
-rw-r--r--    1 root     root         10240 Mar  9 13:07 JUNE-19.tar
-rw-r--r--    1 root     root     174456832 Mar  9 12:56 root:latest
lrwxrwxrwx    1 root     root            20 Mar  9 12:42 llama3.2:1B-1.2B-F32 -> Llama3.2:1B-1.2B-F32
-rw-r--r--    1 root     root      10007808 Mar  9 12:36 MayKeye:latest
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# ls -lt hf.co/
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# 

End Point logs
model_name:  hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf:latest destn_path /tsi/proj/model-cache/gguf/

Response:
 {"status": "success", "model": "ollama", "message": {"content": "Model deleted", "thinking": "Model deleted", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 

127.0.0.1 - - [21/Aug/2025 20:37:03] "POST /api/opu-delete-model HTTP/1.1" 200 -
PRELIMINARY TARGET CHECK-SUM:  md5sum: can't open 'hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf': No such file or directory

PRELIMINARY HOST/SHELL CHECK-SUM:  d9ce4624d6b5414eb97a2ad2c115bea6  /usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991

rm: can't remove 'hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf': No such file or directory

/usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991
process created
======================================
 Running on system: fpga1
======================================
Valid system.. continuing setup
Found PCI device at BDF: 0000:01:00.0
Removing PCI device: 0000:01:00.0
Rescanning PCI bus...
Dumping PCI data using script: /aws/proj/rel/sw/platform/release_v0.1.1.tsv026_04_15_2025/scripts/dump-pci.sh
setpci -s1:0 VENDOR_ID
1172
 setpci -s1:0 DEVICE_ID
0000
 setpci -s1:0 REVISION
00
setpci -s1:0 CLASS_DEVICE
ff00
setpci -s1:0 SUBSYSTEM_VENDOR_ID
0000
 setpci -s1:0 SUBSYSTEM_ID
0000
 setpci -s1:0 BASE_ADDRESS_0
0150000c
setpci -s1:0 BASE_ADDRESS_1
00000060
setpci -s1:0 BASE_ADDRESS_2
0140000c
setpci -s1:0 BASE_ADDRESS_3
00000060
lspci -vvvnns1:0
01:00.0 Unassigned class [ff00]: Altera Corporation Device [1172:0000] (rev 01)
	Control: I/O- Mem+ BusMaster- SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
	Region 0: Memory at 6001500000 (64-bit, prefetchable) [size=64K]
	Region 2: Memory at 6001400000 (64-bit, prefetchable) [size=1M]
	Capabilities: [40] Power Management version 3
		Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0+,D1-,D2-,D3hot+,D3cold-)
		Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
	Capabilities: [70] Express (v2) Endpoint, MSI 00
		DevCap:	MaxPayload 512 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
			ExtTag+ AttnBtn- AttnInd- PwrInd- RBE+ FLReset+ SlotPowerLimit 75.000W
		DevCtl:	CorrErr- NonFatalErr- FatalErr- UnsupReq-
			RlxdOrd+ ExtTag+ PhantFunc- AuxPwr- NoSnoop+ FLReset-
			MaxPayload 256 bytes, MaxReadReq 512 bytes
		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr+ TransPend-
		LnkCap:	Port #1, Speed 16GT/s, Width x16, ASPM not supported
			ClockPM- Surprise- LLActRep- BwNot- ASPMOptComp+
		LnkCtl:	ASPM Disabled; RCB 64 bytes, Disabled- CommClk-
			ExtSynch- ClockPM- AutWidDis- BWInt- AutBWInt-
		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)
			TrErr- Train- SlotClk- DLActive- BWMgmt- ABWMgmt-
		DevCap2: Completion Timeout: Range ABCD, TimeoutDis+ NROPrPrP- LTR+
			 10BitTagComp+ 10BitTagReq+ OBFF Not Supported, ExtFmt+ EETLPPrefix+, MaxEETLPPrefixes 1
			 EmergencyPowerReduction Not Supported, EmergencyPowerReductionInit-
			 FRS- TPHComp+ ExtTPHComp-
			 AtomicOpsCap: 32bit+ 64bit+ 128bitCAS+
		DevCtl2: Completion Timeout: 50us to 50ms, TimeoutDis- LTR+ OBFF Disabled,
			 AtomicOpsCtl: ReqEn-
		LnkCap2: Supported Link Speeds: 2.5-16GT/s, Crosslink- Retimer+ 2Retimers+ DRS-
		LnkCtl2: Target Link Speed: 16GT/s, EnterCompliance- SpeedDis-
			 Transmit Margin: Normal Operating Range, EnterModifiedCompliance- ComplianceSOS-
			 Compliance De-emphasis: -6dB
		LnkSta2: Current De-emphasis Level: -6dB, EqualizationComplete+ EqualizationPhase1+
			 EqualizationPhase2+ EqualizationPhase3+ LinkEqualizationRequest-
			 Retimer- 2Retimers- CrosslinkRes: Upstream Port
	Capabilities: [100 v2] Advanced Error Reporting
		UESta:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
		UEMsk:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
		UESvrt:	DLP+ SDES+ TLP- FCP+ CmpltTO- CmpltAbrt- UnxCmplt- RxOF+ MalfTLP+ ECRC- UnsupReq- ACSViol-
		CESta:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr-
		CEMsk:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr+
		AERCap:	First Error Pointer: 00, ECRCGenCap+ ECRCGenEn- ECRCChkCap+ ECRCChkEn-
			MultHdrRecCap- MultHdrRecEn- TLPPfxPres- HdrLogCap-
		HeaderLog: 00000000 00000000 00000000 00000000
	Capabilities: [148 v1] Virtual Channel
		Caps:	LPEVC=0 RefClk=100ns PATEntryBits=1
		Arb:	Fixed- WRR32- WRR64- WRR128-
		Ctrl:	ArbSelect=Fixed
		Status:	InProgress-
		VC0:	Caps:	PATOffset=00 MaxTimeSlots=1 RejSnoopTrans-
			Arb:	Fixed- WRR32- WRR64- WRR128- TWRR128- WRR256-
			Ctrl:	Enable+ ID=0 ArbSelect=Fixed TC/VC=ff
			Status:	NegoPending- InProgress-
	Capabilities: [174 v1] Alternative Routing-ID Interpretation (ARI)
		ARICap:	MFVC- ACS-, Next Function: 0
		ARICtl:	MFVC- ACS-, Function Group: 0
	Capabilities: [184 v1] Secondary PCI Express
		LnkCtl3: LnkEquIntrruptEn- PerformEqu-
		LaneErrStat: 0
	Capabilities: [1b4 v1] Physical Layer 16.0 GT/s <?>
	Capabilities: [1e4 v1] Lane Margining at the Receiver <?>
	Capabilities: [4ac v1] Data Link Feature <?>
	Capabilities: [d00 v1] Vendor Specific Information: ID=1172 Rev=0 Len=05c <?>
	Kernel modules: altera_cvp

Setting PCI command bit for device: 0000:01:00.0
Command: cd /usr/bin/tsi/v0.1.1*/bin/; ./recvFromHost  /tsi/proj/model-cache/gguf/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991
 Timeout: 900
file_transfer_path /tsi/fpga_card/file-transfer/copy2fpga-x86.sh
process completed
Thread starting
Thread started
sudo ./copy2fpga-x86 /usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991
PCIE base address is: 0x6001400000

BEGIN FILE TRANSFER (Send process): 
====================================
On FPGA Target, Start Receive process. After it has started, press a key <'y/Y'>: File size to be transfered: 4382976 bytes

Starting Transfer >>>>>> 
Current time: 20:38:49
Current date: 2025-08-21
Waiting for receive/reader process to complete... |
Time taken for transfer: 0.529606 seconds
Current time: 20:38:50
Current date: 2025-08-21

File Transfer completed.
Success: 
Receive in progress...


Thread Complete: 
Receive in progress...


Thread exited normally False
Renaming file hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf


Listing out existing files
-rw-r--r--    1 root     root     3012481120 Jul 11  2025 qwen3.gguf
-rw-r--r--    1 100023   100003   4951088896 Jul 11  2025 llama32-1b-instruct.gguf
-rw-r--r--    1 root     root     3012481120 Mar 10  2018 new-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar 10  2018 part-1Gac
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gaa
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gab
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-webui-d45
-rw-r--r--    1 root     root     397149152 Mar 10  2018 karar-test-ed8
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-test-d45
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 karar-test-Tinyllama-1.1B.gguf
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root      36806944 Mar 10  2018 gte-small.Q8_0.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 bge4.gguf
-rw-r--r--    1 root     root      42946355 Mar  9  2018 TinyLlama.tz
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte9.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte2.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 orecvd-gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte8.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte6.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte5.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 custom-model.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 gte7.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte3.gguf
drwxr-xr-x    3 root     root          4096 Mar  9 16:45 hf.co
-rw-r--r--    1 root     root     4951085024 Mar  9 16:19 Llama32-1b-sc.gguf
-rw-r--r--    1 root     root     3012481120 Mar  9 15:50 re-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar  9 15:48 part1-Gac
-rw-r--r--    1 root     root     1073741824 Mar  9 15:25 part1-Gaa
-rw-r--r--    1 root     root     4400979520 Mar  9 14:32 fpga1-Tinygguf
-rw-r--r--    1 root     root      36806944 Mar  9 14:11 my-gte-guuf
-rw-r--r--    1 root     root     4951085024 Mar  9 13:37 Llama3.2:1B-1.2B-F32
-rwxrwxrwx    1 root     root      10007808 Mar  9 13:27 tinyllama-vo-5m-para.gguf
-rw-r--r--    1 root     root     8132911200 Mar  9 13:13 qwen3_1_7b:latest
-rw-r--r--    1 root     root         10240 Mar  9 13:07 JUNE-19.tar
-rw-r--r--    1 root     root     174456832 Mar  9 12:56 root:latest
lrwxrwxrwx    1 root     root            20 Mar  9 12:42 llama3.2:1B-1.2B-F32 -> Llama3.2:1B-1.2B-F32
-rw-r--r--    1 root     root      10007808 Mar  9 12:36 MayKeye:latest

Doing checksum of the upload file
TARGET CHECK-SUM:  d9ce4624d6b5414eb97a2ad2c115bea6  hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf

HOST/SHELL CHECK-SUM:  d9ce4624d6b5414eb97a2ad2c115bea6  /usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991

Response:
 {"status": "success", "model": "ollama", "message": {"content": "File Download Done", "thinking": "File Download Done", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 

127.0.0.1 - - [21/Aug/2025 20:38:55] "POST /api/receive HTTP/1.1" 200 -
model_name:  hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf:latest destn_path /tsi/proj/model-cache/gguf/

Response:
 {"status": "success", "model": "ollama", "message": {"content": "Model deleted", "thinking": "Model deleted", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 

127.0.0.1 - - [21/Aug/2025 20:39:33] "POST /api/opu-delete-model HTTP/1.1" 200 -
PRELIMINARY TARGET CHECK-SUM:  md5sum: can't open 'hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf': No such file or directory

PRELIMINARY HOST/SHELL CHECK-SUM:  d9ce4624d6b5414eb97a2ad2c115bea6  /usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991

rm: can't remove 'hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf': No such file or directory

/usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991
process created
======================================
 Running on system: fpga1
======================================
Valid system.. continuing setup
Found PCI device at BDF: 0000:01:00.0
Removing PCI device: 0000:01:00.0
Rescanning PCI bus...
Dumping PCI data using script: /aws/proj/rel/sw/platform/release_v0.1.1.tsv026_04_15_2025/scripts/dump-pci.sh
setpci -s1:0 VENDOR_ID
1172
 setpci -s1:0 DEVICE_ID
0000
 setpci -s1:0 REVISION
00
setpci -s1:0 CLASS_DEVICE
ff00
setpci -s1:0 SUBSYSTEM_VENDOR_ID
0000
 setpci -s1:0 SUBSYSTEM_ID
0000
 setpci -s1:0 BASE_ADDRESS_0
0150000c
setpci -s1:0 BASE_ADDRESS_1
00000060
setpci -s1:0 BASE_ADDRESS_2
0140000c
setpci -s1:0 BASE_ADDRESS_3
00000060
lspci -vvvnns1:0
01:00.0 Unassigned class [ff00]: Altera Corporation Device [1172:0000] (rev 01)
	Control: I/O- Mem+ BusMaster- SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
	Region 0: Memory at 6001500000 (64-bit, prefetchable) [size=64K]
	Region 2: Memory at 6001400000 (64-bit, prefetchable) [size=1M]
	Capabilities: [40] Power Management version 3
		Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0+,D1-,D2-,D3hot+,D3cold-)
		Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
	Capabilities: [70] Express (v2) Endpoint, MSI 00
		DevCap:	MaxPayload 512 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
			ExtTag+ AttnBtn- AttnInd- PwrInd- RBE+ FLReset+ SlotPowerLimit 75.000W
		DevCtl:	CorrErr- NonFatalErr- FatalErr- UnsupReq-
			RlxdOrd+ ExtTag+ PhantFunc- AuxPwr- NoSnoop+ FLReset-
			MaxPayload 256 bytes, MaxReadReq 512 bytes
		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr+ TransPend-
		LnkCap:	Port #1, Speed 16GT/s, Width x16, ASPM not supported
			ClockPM- Surprise- LLActRep- BwNot- ASPMOptComp+
		LnkCtl:	ASPM Disabled; RCB 64 bytes, Disabled- CommClk-
			ExtSynch- ClockPM- AutWidDis- BWInt- AutBWInt-
		LnkSta:	Speed 16GT/s (ok), Width x16 (ok)
			TrErr- Train- SlotClk- DLActive- BWMgmt- ABWMgmt-
		DevCap2: Completion Timeout: Range ABCD, TimeoutDis+ NROPrPrP- LTR+
			 10BitTagComp+ 10BitTagReq+ OBFF Not Supported, ExtFmt+ EETLPPrefix+, MaxEETLPPrefixes 1
			 EmergencyPowerReduction Not Supported, EmergencyPowerReductionInit-
			 FRS- TPHComp+ ExtTPHComp-
			 AtomicOpsCap: 32bit+ 64bit+ 128bitCAS+
		DevCtl2: Completion Timeout: 50us to 50ms, TimeoutDis- LTR+ OBFF Disabled,
			 AtomicOpsCtl: ReqEn-
		LnkCap2: Supported Link Speeds: 2.5-16GT/s, Crosslink- Retimer+ 2Retimers+ DRS-
		LnkCtl2: Target Link Speed: 16GT/s, EnterCompliance- SpeedDis-
			 Transmit Margin: Normal Operating Range, EnterModifiedCompliance- ComplianceSOS-
			 Compliance De-emphasis: -6dB
		LnkSta2: Current De-emphasis Level: -6dB, EqualizationComplete+ EqualizationPhase1+
			 EqualizationPhase2+ EqualizationPhase3+ LinkEqualizationRequest-
			 Retimer- 2Retimers- CrosslinkRes: Upstream Port
	Capabilities: [100 v2] Advanced Error Reporting
		UESta:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
		UEMsk:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
		UESvrt:	DLP+ SDES+ TLP- FCP+ CmpltTO- CmpltAbrt- UnxCmplt- RxOF+ MalfTLP+ ECRC- UnsupReq- ACSViol-
		CESta:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr-
		CEMsk:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr+
		AERCap:	First Error Pointer: 00, ECRCGenCap+ ECRCGenEn- ECRCChkCap+ ECRCChkEn-
			MultHdrRecCap- MultHdrRecEn- TLPPfxPres- HdrLogCap-
		HeaderLog: 00000000 00000000 00000000 00000000
	Capabilities: [148 v1] Virtual Channel
		Caps:	LPEVC=0 RefClk=100ns PATEntryBits=1
		Arb:	Fixed- WRR32- WRR64- WRR128-
		Ctrl:	ArbSelect=Fixed
		Status:	InProgress-
		VC0:	Caps:	PATOffset=00 MaxTimeSlots=1 RejSnoopTrans-
			Arb:	Fixed- WRR32- WRR64- WRR128- TWRR128- WRR256-
			Ctrl:	Enable+ ID=0 ArbSelect=Fixed TC/VC=ff
			Status:	NegoPending- InProgress-
	Capabilities: [174 v1] Alternative Routing-ID Interpretation (ARI)
		ARICap:	MFVC- ACS-, Next Function: 0
		ARICtl:	MFVC- ACS-, Function Group: 0
	Capabilities: [184 v1] Secondary PCI Express
		LnkCtl3: LnkEquIntrruptEn- PerformEqu-
		LaneErrStat: 0
	Capabilities: [1b4 v1] Physical Layer 16.0 GT/s <?>
	Capabilities: [1e4 v1] Lane Margining at the Receiver <?>
	Capabilities: [4ac v1] Data Link Feature <?>
	Capabilities: [d00 v1] Vendor Specific Information: ID=1172 Rev=0 Len=05c <?>
	Kernel modules: altera_cvp

Setting PCI command bit for device: 0000:01:00.0
Command: cd /usr/bin/tsi/v0.1.1*/bin/; ./recvFromHost  /tsi/proj/model-cache/gguf/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991
 Timeout: 900
file_transfer_path /tsi/fpga_card/file-transfer/copy2fpga-x86.sh
process completed
Thread starting
Thread started
sudo ./copy2fpga-x86 /usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991
PCIE base address is: 0x6001400000

BEGIN FILE TRANSFER (Send process): 
====================================
On FPGA Target, Start Receive process. After it has started, press a key <'y/Y'>: File size to be transfered: 4382976 bytes

Starting Transfer >>>>>> 
Current time: 20:41:12
Current date: 2025-08-21
Waiting for receive/reader process to complete... |
Time taken for transfer: 0.527542 seconds
Current time: 20:41:13
Current date: 2025-08-21

File Transfer completed.
Success: 
Receive in progress...


Thread Complete: 
Receive in progress...


Thread exited normally False
Renaming file hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf


Listing out existing files
-rw-r--r--    1 root     root     3012481120 Jul 11  2025 qwen3.gguf
-rw-r--r--    1 100023   100003   4951088896 Jul 11  2025 llama32-1b-instruct.gguf
-rw-r--r--    1 root     root     3012481120 Mar 10  2018 new-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar 10  2018 part-1Gac
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gaa
-rw-r--r--    1 root     root     1073741824 Mar 10  2018 part-1Gab
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-webui-d45
-rw-r--r--    1 root     root     397149152 Mar 10  2018 karar-test-ed8
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-test-d45
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 karar-test-Tinyllama-1.1B.gguf
-rw-r--r--    1 root     root     4400979520 Mar 10  2018 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root      36806944 Mar 10  2018 gte-small.Q8_0.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 bge4.gguf
-rw-r--r--    1 root     root      42946355 Mar  9  2018 TinyLlama.tz
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte9.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte2.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 orecvd-gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte8.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte6.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte5.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 custom-model.gguf
-rw-r--r--    1 root     root             0 Mar  9  2018 gte7.gguf
-rw-r--r--    1 root     root      36806944 Mar  9  2018 gte3.gguf
drwxr-xr-x    3 root     root          4096 Mar  9 16:47 hf.co
-rw-r--r--    1 root     root     4951085024 Mar  9 16:19 Llama32-1b-sc.gguf
-rw-r--r--    1 root     root     3012481120 Mar  9 15:50 re-qwen3.gguf
-rw-r--r--    1 root     root     864997472 Mar  9 15:48 part1-Gac
-rw-r--r--    1 root     root     1073741824 Mar  9 15:25 part1-Gaa
-rw-r--r--    1 root     root     4400979520 Mar  9 14:32 fpga1-Tinygguf
-rw-r--r--    1 root     root      36806944 Mar  9 14:11 my-gte-guuf
-rw-r--r--    1 root     root     4951085024 Mar  9 13:37 Llama3.2:1B-1.2B-F32
-rwxrwxrwx    1 root     root      10007808 Mar  9 13:27 tinyllama-vo-5m-para.gguf
-rw-r--r--    1 root     root     8132911200 Mar  9 13:13 qwen3_1_7b:latest
-rw-r--r--    1 root     root         10240 Mar  9 13:07 JUNE-19.tar
-rw-r--r--    1 root     root     174456832 Mar  9 12:56 root:latest
lrwxrwxrwx    1 root     root            20 Mar  9 12:42 llama3.2:1B-1.2B-F32 -> Llama3.2:1B-1.2B-F32
-rw-r--r--    1 root     root      10007808 Mar  9 12:36 MayKeye:latest

Doing checksum of the upload file
TARGET CHECK-SUM:  d9ce4624d6b5414eb97a2ad2c115bea6  hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf

HOST/SHELL CHECK-SUM:  d9ce4624d6b5414eb97a2ad2c115bea6  /usr/share/ollama/.ollama/models/blobs/sha256-f974d645f494d97ba5edec964ee97d3ad296b7fe0136daace02a657fdd77c991

Response:
 {"status": "success", "model": "ollama", "message": {"content": "File Download Done", "thinking": "File Download Done", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 

127.0.0.1 - - [21/Aug/2025 20:41:17] "POST /api/receive HTTP/1.1" 200 -
model_name:  hf.co/RichardErkhov/Maykeye_-_TinyLLama-v0-gguf:latest destn_path /tsi/proj/model-cache/gguf/

Response:
 {"status": "success", "model": "ollama", "message": {"content": "Model deleted", "thinking": "Model deleted", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true} 

127.0.0.1 - - [21/Aug/2025 20:42:11] "POST /api/opu-delete-model HTTP/1.1" 200 -

