### PR TITLE
@FIR-913 - Open_webUI:Disable Follow-Up/Title/Tag Auto-Generation by …

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -891,9 +891,11 @@
 		const userSettings = await getUserSettings(localStorage.token);
 
 		if (userSettings) {
-			settings.set(userSettings.ui);
+			settings.set({ ...userSettings.ui, autoFollowUps: false });
+
 		} else {
-			settings.set(JSON.parse(localStorage.getItem('settings') ?? '{}'));
+			settings.set({ ...JSON.parse(localStorage.getItem('settings') ?? '{}'), autoFollowUps: false });
+
 		}
 
 		const chatInput = document.getElementById('chat-input');
@@ -943,9 +945,12 @@
 				const userSettings = await getUserSettings(localStorage.token);
 
 				if (userSettings) {
-					await settings.set(userSettings.ui);
+					await settings.set({ ...userSettings.ui, autoFollowUps: false });
+
+
 				} else {
-					await settings.set(JSON.parse(localStorage.getItem('settings') ?? '{}'));
+					await settings.set({ ...JSON.parse(localStorage.getItem('settings') ?? '{}'), autoFollowUps: false });
+
 				}
 
 				params = chatContent?.params ?? {};
@@ -1770,7 +1775,7 @@
 								tags_generation: $settings?.autoTags ?? true
 							}
 						: {}),
-					follow_up_generation: $settings?.autoFollowUps ?? true
+					follow_up_generation: false
 				},
 
 				...(stream && (model.info?.meta?.capabilities?.usage ?? false)


### PR DESCRIPTION
 This ensures that autoFollowUps is explicitly disabled across all settings sources:
	•	Merged settings from backend (getUserSettings) and localStorage now override autoFollowUps to false.
	•	Prompt generation logic hardcodes follow_up_generation: false to prevent accidental enablement.
	•	UI settings panel may still show it as enabled if not overridden correctly — this fix ensures consistency.


