### PR TITLE
@FIR-913 - Open_webUI:Disable Follow-Up/Title/Tag Auto-Generation by Default

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -891,12 +891,18 @@
 		const userSettings = await getUserSettings(localStorage.token);
 
 		if (userSettings) {
-			settings.set({ ...userSettings.ui, autoFollowUps: false, title: { auto: false }, autoTags: false });
-
+			settings.set({
+				...userSettings.ui,
+				autoFollowUps: false,
+				title: { auto: false },
+				autoTags: false });
 
 		} else {
-			settings.set({ ...JSON.parse(localStorage.getItem('settings') ?? '{}'), autoFollowUps: false, title: { auto: false }, autoTags: false
-});
+			settings.set({
+				...JSON.parse(localStorage.getItem('settings') ?? '{}'),
+				autoFollowUps: false,
+				title: { auto: false },
+				autoTags: false});
 		}
 
 		const chatInput = document.getElementById('chat-input');
@@ -952,6 +958,22 @@
 				} else {
 					await settings.set({ ...JSON.parse(localStorage.getItem('settings') ?? '{}'), autoFollowUps: false });
 
+				}
+				if (userSettings) {
+    					await settings.set({
+        					...userSettings.ui,
+        					autoFollowUps: false,
+        					autoTags: false,
+        					autoTitle: false
+    					});
+				} else {
+    					const localSettings = JSON.parse(localStorage.getItem('settings') ?? '{}');
+    					await settings.set({
+        					...localSettings,
+        					autoFollowUps: false,
+        					autoTags: false,
+        					autoTitle: false
+    					});
 				}
 
 				params = chatContent?.params ?? {};
@@ -1772,8 +1794,8 @@
 							messages.at(1)?.role === 'user')) &&
 					(selectedModels[0] === model.id || atSelectedModel !== undefined)
 						? {
-								title_generation: $settings?.title?.auto ?? true,
-								tags_generation: $settings?.autoTags ?? true
+								title_generation: false,
+								tags_generation: false
 							}
 						: {}),
 					follow_up_generation: false


### PR DESCRIPTION
disable automatic generation of:

Follow-up questions
Chat titles
Tags
This ensures that these features are turned off by default, regardless of user settings or local storage values.

Impacted Features
Chat Initialization: Prevents auto-follow-up logic from activating when a new chat is started.
Chat Completion: Ensures no title or tag generation occurs after assistant responses.
User Experience: Users will not see automatically generated follow-ups, titles, or tags unless manually enabled.
Testing:
I have manually validated at OPU and native at FPGA2
