### PR TITLE
@FIR-915: Disable the Voice Mode when the command prompt is running

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -106,6 +106,7 @@
 	export let codeInterpreterEnabled = false;
 
 	let showInputVariablesModal = false;
+	let showVoiceMode = false;
 	let inputVariables = {};
 	let inputVariableValues = {};
 
@@ -1927,6 +1928,7 @@
 											</div>
 										{#if false} // remove unsupported functionality for TSI
 										{:else if prompt === '' && files.length === 0 && ($_user?.role === 'admin' || ($_user?.permissions?.chat?.call ?? true))}
+										{#if showVoiceMode} // remove unsupported functionality for TSI
 											<div class=" flex items-center">
 												<!-- {$i18n.t('Call')} -->
 												<Tooltip content={$i18n.t('Voice mode')}>
@@ -1989,6 +1991,7 @@
 													</button>
 												</Tooltip>
 											</div>
+										{/if}
 										{/if}
 										{:else}
 											<div class=" flex items-center">


### PR DESCRIPTION
The changes disable the Voice Mode fully, since this is svelte file even after disabling the file was being parsed and the prompt showing input mode for Voice mode. Disabling this piece of code fully by putting it in {#if showVoiceMode } block.

the test results are as follows
Before
<img width="1471" height="939" alt="Screenshot 2025-08-23 193652" src="https://github.com/user-attachments/assets/13932250-6ba6-4fe8-8a0c-1f411beef5c5" />

and After
<img width="2128" height="1594" alt="Screenshot 2025-08-23 193238" src="https://github.com/user-attachments/assets/c187574f-346c-41d6-bcbd-6c7cf1b2a0d1" />

