### PR TITLE
@FIR-930: Disabled ability to choose CPU and Native as target

### DIFF
--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -70,8 +70,10 @@
 					bind:value={params.target}
 				>
 					<option value="opu">{$i18n.t('OPU')}</option>
-					<option value="cpu">{$i18n.t('CPU')}</option>
-					<option value="native">{$i18n.t('Native')}</option>
+					<!-- Limit Option to OPU only for customer releases
+						<option value="cpu">{$i18n.t('CPU')}</option>
+						<option value="native">{$i18n.t('Native')}</option>
+					-->
 				</select>
 			</div>
 		</Tooltip>


### PR DESCRIPTION
The change limits the selection of target to default OPU and no other options are available

The test results are as follows

<img width="1349" height="739" alt="Screenshot 2025-09-02 144218" src="https://github.com/user-attachments/assets/54503a81-c6e5-41af-827a-98186b0118ea" />
<img width="1349" height="735" alt="Screenshot 2025-09-02 144248" src="https://github.com/user-attachments/assets/048f5d97-c508-4a92-aadb-0442fa3883cf" />
<img width="1355" height="740" alt="Screenshot 2025-09-02 144616" src="https://github.com/user-attachments/assets/1cab1bff-4fa9-48ed-815b-bd56114cbfd0" />

