### PR TITLE
@FIR-932: Updated all endpoints to check for flask busy

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -259,6 +259,8 @@ def receive_upload_model():
 
     data = request.get_json()
     incoming_headers = dict(request.headers)
+    if is_job_running() == True:
+        return manual_response(content="Server is busy. Please try again later.",thinking=None,profile_data=None, incoming_headers=incoming_headers), 200
 
     file_name = os.path.basename(data['actual_name'])
 
@@ -330,6 +332,9 @@ def receive_pull_model():
 
     data = request.get_json()
     incoming_headers = dict(request.headers)
+
+    if is_job_running() == True:
+        return manual_response(content="Server is busy. Please try again later.",thinking=None,profile_data=None, incoming_headers=incoming_headers), 200
 
     try:
         test1 = data['human_name']
@@ -418,11 +423,13 @@ def denormalize_model_name(model_name):
 
 @app.route('/api/opu-delete-model', methods=['GET', 'POST'])
 def opu_delete_model():
-    serial_script.pre_and_post_check(port,baudrate)
     data = request.get_json()
 
     incoming_headers = dict(request.headers)
+    if is_job_running() == True:
+        return manual_response(content="Server is busy. Please try again later.",thinking=None,profile_data=None, incoming_headers=incoming_headers), 200
 
+    serial_script.pre_and_post_check(port,baudrate)
     try:
         model_name = data['model_name']
         print("model_name: ", model_name, "destn_path", destn_path)
@@ -883,12 +890,18 @@ def restart_txe_ollama_serial_command():
 @app.route('/api/system-info', methods=['GET', 'POST'])
 def system_info_ollama_serial_command():
     incoming_headers = dict(request.headers)
+    if is_job_running() == True:
+        return manual_response(content="Server is busy. Please try again later.",thinking=None,profile_data=None, incoming_headers=incoming_headers), 200
+
     result, error = system_info_serial_command()
     return manual_response(content=result,thinking="System Info", incoming_headers=incoming_headers), error
 
 @app.route('/api/health-check', methods=['GET', 'POST'])
 def health_check_ollama_serial_command():
     incoming_headers = dict(request.headers)
+    if is_job_running() == True:
+        return manual_response(content="Server is busy. Please try again later.",thinking=None,profile_data=None, incoming_headers=incoming_headers), 200
+
     result, error = health_check_serial_command()
     return manual_response(content=result,thinking="Health Check", incoming_headers=incoming_headers), error
 


### PR DESCRIPTION
The change checks for all end points before sending commands to target

The end points tested are
1. Chat prompts
2. Task Abort
3. System Info
4. Health Check
5. File Upload/Delete

The test results are here
Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My cat is'}], 'stream': True} Response:
 {"status": "success", "model": "ollama", "message": {"content": "Server is busy. Please try again later.", "thinking": null, "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Response:
 {"status": "success", "model": "ollama", "message": {"content": "Server is busy. Please try again later.", "thinking": null, "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000a little girl called Sam and he is very excited. They want to find something special. They look on the table and see some leaves, but they are too high up in the ground.\n\"Maybe it can do that,\" said Sam.\nHe picks up his tail and runs outside and sees the water. He says, \"It's so cool! You can help me see how well you will find!\"\nHe laughs and tells Sam, \"I will be careful and get a bandage.\"\nSam says, \"Yes, I will do it with this one. It is very special too,\"\nThe mule\n\n", "thinking": "\u0000a little girl called Sam and he is very excited. They want to find something special. They look on the table and see some leaves, but they are too high up in the ground.\n\"Maybe it can do that,\" said Sam.\nHe picks up his tail and runs outside and sees the water. He says, \"It's so cool! You can help me see how well you will find!\"\nHe laughs and tells Sam, \"I will be careful and get a bandage.\"\nSam says, \"Yes, I will do it with this one. It is very special too,\"\nThe mule\n\n", "tool_calls": null, "openai_tool_calls": null, "meta": "   sampling time =    3285.97 ms /   132 runs   (   24.89 ms per token,    40.17 tokens per second)llama_perf_context_print:        load time =    1439.55 ms\nllama_perf_context_print: prompt eval time =     203.44 ms /     4 tokens (   50.86 ms per token,    19.66 tokens per second)\nllama_perf_context_print:        eval time =   11052.89 ms /   127 runs   (   87.03 ms per token,    11.49 tokens per second)\nllama_perf_context_print:       total time =   16070.78 ms /   131 tokens\n\n=== GGML Perf Summary ===\nOp              :    Runs        Total us            Avg us\nADD             :    2048         1419599            693.16\n[TSAVORITE ] :    2048         1419599            693.16\nMUL             :    3200         2327892            727.47\n[TSAVORITE ] :    3200         2327892            727.47\nRMS_NORM        :    6866           20221              2.95\n[CPU       ] :    6866           20221              2.95\nMUL_MAT         :   30772        18030070            585.92\n[CPU       ] :   30772        18030070            585.92\nCPY             :    6608           29407              4.45\n[CPU       ] :    6608           29407              4.45\nCONT            :    2643            7584              2.87\n[CPU       ] :    2643            7584              2.87\nRESHAPE         :    8353            6666              0.80\n[CPU       ] :    8353            6666              0.80\nVIEW            :    7487            4955              0.66\n[CPU       ] :    7487            4955              0.66\nPERMUTE         :    7587            5429              0.72\n[CPU       ] :    7587            5429              0.72\nTRANSPOSE       :    1854            1976              1.07\n[CPU       ] :    1854            1976              1.07\nGET_ROWS        :     990            5957              6.02\n[CPU       ] :     990            5957              6.02\nSOFT_MAX        :    3502          363434            103.78\n[CPU       ] :    3502          363434            103.78\nROPE            :    5189           29896              5.76\n[CPU       ] :    5189           29896              5.76\nUNARY           :    1024          707882            691.29\n[TSAVORITE ] :    1024          707882            691.29\n-> SILU        :    1024          707882            691.29\nsaid\n\n\nGGML Tsavorite Profiling Results:\n------------------------------------------------------------------------------------------------------------------------\nCalls  Total(ms)    T/call    Self(ms)  Function\n------------------------------------------------------------------------------------------------------------------------\n1    20.6450   20.6450      1.3140  [1.21e-01%] [Thread] GGML Tsavorite\n1    19.3310   19.3310     17.6520  \u2514\u2500 [1.14e-01%] tsi::runtime::TsavRTFPGA::initialize\n1     0.9130    0.9130      0.9130    \u2514\u2500 [5.37e-03%] tsi::runtime::TsavRTFPGA::initializeQueues\n1     0.5840    0.5840      0.5840    \u2514\u2500 [3.43e-03%] tsi::runtime::TsavRT::initialize\n1     0.1820    0.1820      0.1270    \u2514\u2500 [1.07e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand\n2     0.0550    0.0275      0.0550      \u2514\u2500 [3.23e-04%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6380  1231.9450    0.1931      0.0000  [ 7.24%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion\n6380 28406.3964    4.4524  28406.3964  \u2514\u2500 [167.02%] TXE 0 Idle\n3266   632.5155    0.1937    632.5155  \u2514\u2500 [ 3.72%] [ txe_mult ]\n2090   383.1803    0.1833    383.1803  \u2514\u2500 [ 2.25%] [ txe_add ]\n1024   241.5913    0.2359    241.5913  \u2514\u2500 [ 1.42%] [ txe_silu ]\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6380   642.4650    0.1007    601.7820  [ 3.78%] [Thread] tsi::runtime::TsavRT::finalizeCommandList\n6380    40.6830    0.0064     40.6830  \u2514\u2500 [2.39e-01%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6380  1234.5000    0.1935    133.1310  [ 7.26%] [Thread] tsi::runtime::TsavRT::processResponses\n6380  1101.3690    0.1726   1101.3690  \u2514\u2500 [ 6.48%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1    35.3920   35.3920     34.5370  [2.08e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize\n1     0.8550    0.8550      0.8550  \u2514\u2500 [5.03e-03%] tsi::runtime::TsavRTFPGA::releaseTxes\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6381    84.1290    0.0132     84.1290  [4.95e-01%] [Thread] tsi::runtime::TsavRT::allocate\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6380  1040.6010    0.1631   1040.6010  [ 6.12%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6380   223.6180    0.0350    223.6180  [ 1.31%] [Thread] tsi::runtime::TsavRT::addCommandToList\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6380   467.4990    0.0733    467.4990  [ 2.75%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6380    67.2460    0.0105     67.2460  [3.95e-01%] [Thread] tsi::runtime::TsavRT::deallocate\n========================================================================================================================\n- 17007.2900    0.0000  17007.2900  [100.00%] TOTAL\n========================================================================================================================\n\nCounter Metrics:\n------------------------------------------------------------------------------------------------------------------------\nMetric                                    Min            Max            Avg\n------------------------------------------------------------------------------------------------------------------------\nQueue_0_Occupancy                      0.0000         1.0000         0.9870\n------------------------------------------------------------------------------------------------------------------------\n\n"}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My cat and dog are'}], 'stream': True} Response:
 {"status": "success", "model": "ollama", "message": {"content": "Server is busy. Please try again later.", "thinking": null, "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000a little girl. They want to play in the park. The sun was shining, and the wind is shining. The big cat does not like the little girl. He likes to run and jump.\nThe little girl wants to play. She feels sad and ran away. She fell on the ground and throws her paws away. The little girl felt sad. She did not want to play with her friends anymore.\nShe looked for his toys in a hole. She saw some toy balls in the ground. She took them to her house. She took out a big box and took it to her mom. Her mom was very happy\n\n\n\n", "thinking": "\u0000a little girl. They want to play in the park. The sun was shining, and the wind is shining. The big cat does not like the little girl. He likes to run and jump.\nThe little girl wants to play. She feels sad and ran away. She fell on the ground and throws her paws away. The little girl felt sad. She did not want to play with her friends anymore.\nShe looked for his toys in a hole. She saw some toy balls in the ground. She took them to her house. She took out a big box and took it to her mom. Her mom was very happy\n\n\n\n", "tool_calls": null, "openai_tool_calls": null, "meta": "   sampling time =    3139.57 ms /   134 runs   (   23.43 ms per token,    42.68 tokens per second)llama_perf_context_print:        load time =    1484.35 ms\nllama_perf_context_print: prompt eval time =     247.17 ms /     6 tokens (   41.19 ms per token,    24.27 tokens per second)\nllama_perf_context_print:        eval time =   11029.61 ms /   127 runs   (   86.85 ms per token,    11.51 tokens per second)\nllama_perf_context_print:       total time =   15944.73 ms /   133 tokens\n\n=== GGML Perf Summary ===\nOp              :    Runs        Total us            Avg us\nADD             :    2048         1429754            698.12\n[TSAVORITE ] :    2048         1429754            698.12\nMUL             :    3200         2343919            732.47\n[TSAVORITE ] :    3200         2343919            732.47\nRMS_NORM        :    6820           19628              2.88\n[CPU       ] :    6820           19628              2.88\nMUL_MAT         :   30428        18401798            604.77\n[CPU       ] :   30428        18401798            604.77\nCPY             :    6478           29926              4.62\n[CPU       ] :    6478           29926              4.62\nCONT            :    2711            7733              2.85\n[CPU       ] :    2711            7733              2.85\nRESHAPE         :    8207            6269              0.76\n[CPU       ] :    8207            6269              0.76\nVIEW            :    7501            4936              0.66\n[CPU       ] :    7501            4936              0.66\nPERMUTE         :    7677            5652              0.74\n[CPU       ] :    7677            5652              0.74\nTRANSPOSE       :    1810            1851              1.02\n[CPU       ] :    1810            1851              1.02\nGET_ROWS        :    1010            6125              6.06\n[CPU       ] :    1010            6125              6.06\nSOFT_MAX        :    3517          380901            108.30\n[CPU       ] :    3517          380901            108.30\nROPE            :    5259           29773              5.66\n[CPU       ] :    5259           29773              5.66\nUNARY           :    1024          705882            689.34\n[TSAVORITE ] :    1024          705882            689.34\n-> SILU        :    1024          705882            689.34\n\nGGML Tsavorite Profiling Results:\n------------------------------------------------------------------------------------------------------------------------\nCalls  Total(ms)    T/call    Self(ms)  Function\n------------------------------------------------------------------------------------------------------------------------\n1    20.6320   20.6320      1.3120  [1.22e-01%] [Thread] GGML Tsavorite\n1    19.3200   19.3200     17.6150  \u2514\u2500 [1.14e-01%] tsi::runtime::TsavRTFPGA::initialize\n1     0.9140    0.9140      0.9140    \u2514\u2500 [5.41e-03%] tsi::runtime::TsavRTFPGA::initializeQueues\n1     0.6070    0.6070      0.6070    \u2514\u2500 [3.60e-03%] tsi::runtime::TsavRT::initialize\n1     0.1840    0.1840      0.1300    \u2514\u2500 [1.09e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand\n2     0.0540    0.0270      0.0540      \u2514\u2500 [3.20e-04%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6452  1239.2770    0.1921      0.0000  [ 7.34%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion\n6452 28145.9612    4.3624  28145.9612  \u2514\u2500 [166.72%] TXE 0 Idle\n3310   640.7778    0.1936    640.7778  \u2514\u2500 [ 3.80%] [ txe_mult ]\n2118   388.3877    0.1834    388.3877  \u2514\u2500 [ 2.30%] [ txe_add ]\n1024   242.3707    0.2367    242.3707  \u2514\u2500 [ 1.44%] [ txe_silu ]\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6452   641.0060    0.0993    600.3510  [ 3.80%] [Thread] tsi::runtime::TsavRT::finalizeCommandList\n6452    40.6550    0.0063     40.6550  \u2514\u2500 [2.41e-01%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6452  1235.3190    0.1915    131.4060  [ 7.32%] [Thread] tsi::runtime::TsavRT::processResponses\n6452  1103.9130    0.1711   1103.9130  \u2514\u2500 [ 6.54%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1    35.3820   35.3820     34.5740  [2.10e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize\n1     0.8080    0.8080      0.8080  \u2514\u2500 [4.79e-03%] tsi::runtime::TsavRTFPGA::releaseTxes\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6453    83.4850    0.0129     83.4850  [4.95e-01%] [Thread] tsi::runtime::TsavRT::allocate\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6452  1056.2010    0.1637   1056.2010  [ 6.26%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6452   227.0950    0.0352    227.0950  [ 1.35%] [Thread] tsi::runtime::TsavRT::addCommandToList\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6452   472.6970    0.0733    472.6970  [ 2.80%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6452    67.9300    0.0105     67.9300  [4.02e-01%] [Thread] tsi::runtime::TsavRT::deallocate\n========================================================================================================================\n- 16882.6010    0.0000  16882.6010  [100.00%] TOTAL\n========================================================================================================================\n\nCounter Metrics:\n------------------------------------------------------------------------------------------------------------------------\nMetric                                    Min            Max            Avg\n------------------------------------------------------------------------------------------------------------------------\nQueue_0_Occupancy                      0.0000         1.0000         0.9871\n------------------------------------------------------------------------------------------------------------------------\n\n"}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My cat and dog and pets'}], 'stream': True} Sending Ctrl-C to abort current task...
Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000. They are a very happy dog. They like to play together, but they do not find any.\n", "thinking": "\u0000. They are a very happy dog. They like to play together, but they do not find any.\n", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

TXE Manager cleanup and restart successful.
Response:
 {"status": "success", "model": "ollama", "message": {"content": null, "thinking": "Abort Task", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My cat and dog and pets'}], 'stream': True} Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My cat and dog are'}], 'stream': True} Response:
 {"status": "success", "model": "ollama", "message": {"content": "Server is busy. Please try again later.", "thinking": null, "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My cat and dog and pets'}], 'stream': True} Response:
 {"status": "success", "model": "ollama", "message": {"content": "Server is busy. Please try again later.", "thinking": null, "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000. They have a big, warm yard in their house. The big, blue plane is very soft and happy. The little, old truck was full of yummy food with many things to eat.\nOne day, the new toy bird wanted to play with the new dog. The big, strong dog said, \"Hi, cat! I want to play with you!\" The small, brown dog was so happy and took the car for a ride. They played together in the garden and had lots of fun.\nBut then, something unexpected happened. A big wind came and blew all his toys away. The small red ball was\n\n\n\n", "thinking": "\u0000. They have a big, warm yard in their house. The big, blue plane is very soft and happy. The little, old truck was full of yummy food with many things to eat.\nOne day, the new toy bird wanted to play with the new dog. The big, strong dog said, \"Hi, cat! I want to play with you!\" The small, brown dog was so happy and took the car for a ride. They played together in the garden and had lots of fun.\nBut then, something unexpected happened. A big wind came and blew all his toys away. The small red ball was\n\n\n\n", "tool_calls": null, "openai_tool_calls": null, "meta": "   sampling time =    3220.85 ms /   135 runs   (   23.86 ms per token,    41.91 tokens per second)llama_perf_context_print:        load time =    1516.55 ms\nllama_perf_context_print: prompt eval time =     279.08 ms /     7 tokens (   39.87 ms per token,    25.08 tokens per second)\nllama_perf_context_print:        eval time =   11145.43 ms /   127 runs   (   87.76 ms per token,    11.39 tokens per second)\nllama_perf_context_print:       total time =   16173.24 ms /   134 tokens\n\n=== GGML Perf Summary ===\nOp              :    Runs        Total us            Avg us\nADD             :    2048         1447488            706.78\n[TSAVORITE ] :    2048         1447488            706.78\nMUL             :    3200         2448045            765.01\n[TSAVORITE ] :    3200         2448045            765.01\nRMS_NORM        :    6891           19923              2.89\n[CPU       ] :    6891           19923              2.89\nMUL_MAT         :   30365        18142705            597.49\n[CPU       ] :   30365        18142705            597.49\nCPY             :    6447           31076              4.82\n[CPU       ] :    6447           31076              4.82\nCONT            :    2630            7487              2.85\n[CPU       ] :    2630            7487              2.85\nRESHAPE         :    8378            6336              0.76\n[CPU       ] :    8378            6336              0.76\nVIEW            :    7494            4910              0.66\n[CPU       ] :    7494            4910              0.66\nPERMUTE         :    7626            5890              0.77\n[CPU       ] :    7626            5890              0.77\nTRANSPOSE       :    1891            2004              1.06\n[CPU       ] :    1891            2004              1.06\nGET_ROWS        :     995            6019              6.05\n[CPU       ] :     995            6019              6.05\nSOFT_MAX        :    3240          350359            108.14\n[CPU       ] :    3240          350359            108.14\nROPE            :    5057           26209              5.18\n[CPU       ] :    5057           26209              5.18\nUNARY           :    1024          708732            692.12\n[TSAVORITE ] :    1024          708732            692.12\n-> SILU        :    1024          708732            692.12\n\nGGML Tsavorite Profiling Results:\n------------------------------------------------------------------------------------------------------------------------\nCalls  Total(ms)    T/call    Self(ms)  Function\n------------------------------------------------------------------------------------------------------------------------\n1    20.4610   20.4610      1.3220  [1.20e-01%] [Thread] GGML Tsavorite\n1    19.1390   19.1390     17.4290  \u2514\u2500 [1.12e-01%] tsi::runtime::TsavRTFPGA::initialize\n1     0.9140    0.9140      0.9140    \u2514\u2500 [5.34e-03%] tsi::runtime::TsavRTFPGA::initializeQueues\n1     0.6130    0.6130      0.6130    \u2514\u2500 [3.58e-03%] tsi::runtime::TsavRT::initialize\n1     0.1830    0.1830      0.1280    \u2514\u2500 [1.07e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand\n2     0.0550    0.0275      0.0550      \u2514\u2500 [3.21e-04%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6488  1245.8480    0.1920      0.0000  [ 7.28%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion\n6488 28589.6017    4.4065  28589.6017  \u2514\u2500 [167.08%] TXE 0 Idle\n3332   645.3615    0.1937    645.3615  \u2514\u2500 [ 3.77%] [ txe_mult ]\n2132   390.6910    0.1833    390.6910  \u2514\u2500 [ 2.28%] [ txe_add ]\n1024   243.4752    0.2378    243.4752  \u2514\u2500 [ 1.42%] [ txe_silu ]\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6488   729.3710    0.1124    687.4070  [ 4.26%] [Thread] tsi::runtime::TsavRT::finalizeCommandList\n6488    41.9640    0.0065     41.9640  \u2514\u2500 [2.45e-01%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6488  1330.6340    0.2051    133.2790  [ 7.78%] [Thread] tsi::runtime::TsavRT::processResponses\n6488  1197.3550    0.1845   1197.3550  \u2514\u2500 [ 7.00%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1    35.4930   35.4930     34.6350  [2.07e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize\n1     0.8580    0.8580      0.8580  \u2514\u2500 [5.01e-03%] tsi::runtime::TsavRTFPGA::releaseTxes\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6489    86.2590    0.0133     86.2590  [5.04e-01%] [Thread] tsi::runtime::TsavRT::allocate\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6488  1072.0790    0.1652   1072.0790  [ 6.27%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6488   230.1600    0.0355    230.1600  [ 1.35%] [Thread] tsi::runtime::TsavRT::addCommandToList\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6488   475.1490    0.0732    475.1490  [ 2.78%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n6488    68.0950    0.0105     68.0950  [3.98e-01%] [Thread] tsi::runtime::TsavRT::deallocate\n========================================================================================================================\n- 17111.2640    0.0000  17111.2640  [100.00%] TOTAL\n========================================================================================================================\n\nCounter Metrics:\n------------------------------------------------------------------------------------------------------------------------\nMetric                                    Min            Max            Avg\n------------------------------------------------------------------------------------------------------------------------\nQueue_0_Occupancy                      0.0000         1.0000         0.9906\n------------------------------------------------------------------------------------------------------------------------\n\n"}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

<img width="1355" height="740" alt="Screenshot 2025-09-02 144616" src="https://github.com/user-attachments/assets/2fba59ea-e918-466e-8cde-512b1dd2e7e3" />
<img width="1344" height="729" alt="Screenshot 2025-09-02 154956" src="https://github.com/user-attachments/assets/a0bb9681-b5a7-4ed2-b167-4bdc4406f079" />
<img width="1342" height="730" alt="Screenshot 2025-09-02 155006" src="https://github.com/user-attachments/assets/7e8565e9-821d-4e8c-87f0-734bf3147e77" />
