### PR TITLE
@FIR-934: This change handles new profile output change for tsi-ggml

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -26,10 +26,10 @@ exe_path = "/usr/bin/tsi/v0.1.1*/bin/"
 
 DEFAULT_MODEL = "TinyLlama:latest"
 DEFAULT_BACKEND = "tSavorite"
-DEFAULT_TOKEN = 128 # This matches what we have on Open-WebUI
+DEFAULT_TOKEN = 20 # This matches what we have on Open-WebUI
 DEFAULT_REPEAT_PENALTY = 1.1
 DEFAULT_BATCH_SIZE = 512
-DEFAULT_TOP_K = 40
+DEFAULT_TOP_K = 4 # This matches what we have on Open-WebUI
 DEFAULT_TOP_P = 0.9
 DEFAULT_LAST_N = 64
 DEFAULT_CONTEXT_LENGTH = 2048
@@ -743,7 +743,7 @@ def chats():
                 response_text = result
                 start_phrases = [
                     "llama_perf_sampler_print: ",
-                    "GGML Tsavorite Profiling Results:"
+                    "OPU Profiling Results:"
                 ]
 
                 matched_phrase = next((phrase for phrase in start_phrases if phrase in response_text), None)
@@ -846,7 +846,7 @@ def chat():
                 response_text = result
                 start_phrases = [
                     "llama_perf_sampler_print: ",
-                    "GGML Tsavorite Profiling Results:"
+                    "OPU Profiling Results:"
                 ]
                 matched_phrase = next((phrase for phrase in start_phrases if phrase in response_text), None)
 


### PR DESCRIPTION
The change consists of following
1. Updating the string to look for "OPU profile" data instead of old "GGML Tsavorite profile" string
2. Updates flask defaults to match UI defaults

the test results are as follows
 Lily and her mom were in the kitchen. They had a big bowl of food to eat. Lily

llama_perf_sampler_print:    sampling time =     479.09 ms /    24 runs   (   19.96 ms per token,    50.09 tokens per second)
llama_perf_context_print:        load time =    1532.77 ms
llama_perf_context_print: prompt eval time =     183.28 ms /     4 tokens (   45.82 ms per token,    21.82 tokens per second)
llama_perf_context_print:        eval time =    1730.23 ms /    19 runs   (   91.06 ms per token,    10.98 tokens per second)
llama_perf_context_print:       total time =    3787.56 ms /    23 tokens

=== GGML Perf Summary ===
  Op                   Runs        Total us            Avg us
  ADD                   320          241528            754.77
  MUL                   500          403619            807.24
  RMS_NORM             1079            3301              3.06
  MUL_MAT              4750         2858950            601.88
  CPY                  1004            4821              4.80
  CONT                  455            1287              2.83
  RESHAPE              1299             984              0.76
  VIEW                 1158             881              0.76
  PERMUTE              1138             831              0.73
  TRANSPOSE             324             271              0.84
  GET_ROWS              152             935              6.15
  SOFT_MAX              535           26524             49.58
  ROPE                  834            6079              7.29
  UNARY                 160          113608            710.05
    -> SILU             160          113608            710.05

OPU Profiling Results:
------------------------------------------------------------------------------------------------------------------------
Calls  Total(ms)    T/call    Self(ms)  Function
------------------------------------------------------------------------------------------------------------------------
    1    28.7250   28.7250      2.4440  [6.18e-01%] [Thread] OPU
    1    26.2810   26.2810     22.5370  └─ [5.66e-01%] tsi::runtime::TsavRTFPGA::initialize
    1     2.5570    2.5570      2.5570    └─ [5.50e-02%] tsi::runtime::TsavRTFPGA::initializeQueues
    1     0.6270    0.6270      0.6270    └─ [1.35e-02%] tsi::runtime::TsavRT::initialize
    1     0.5600    0.5600      0.5000    └─ [1.21e-02%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand
    2     0.0600    0.0300      0.0600      └─ [1.29e-03%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1088   218.4210    0.2008      0.0000  [ 4.70%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion
 1088  4806.1405    4.4174   4806.1405  └─ [103.42%] TXE 0 Idle
  566   109.6963    0.1938    109.6963  └─ [ 2.36%] [ txe_mult ]
  362    66.2901    0.1831     66.2901  └─ [ 1.43%] [ txe_add ]
  160    36.4302    0.2277     36.4302  └─ [7.84e-01%] [ txe_silu ]
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1088   110.5610    0.1016    103.2210  [ 2.38%] [Thread] tsi::runtime::TsavRT::finalizeCommandList
 1088     7.3400    0.0067      7.3400  └─ [1.58e-01%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1088   213.2980    0.1960     23.4920  [ 4.59%] [Thread] tsi::runtime::TsavRT::processResponses
 1088   189.8060    0.1745    189.8060  └─ [ 4.08%] tsi::runtime::executeWithTimeout
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
    1    35.5520   35.5520     34.7110  [7.65e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize
    1     0.8410    0.8410      0.8410  └─ [1.81e-02%] tsi::runtime::TsavRTFPGA::releaseTxes
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1089    15.7290    0.0144     15.7290  [3.38e-01%] [Thread] tsi::runtime::TsavRT::allocate
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1088   167.2800    0.1537    167.2800  [ 3.60%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1088    45.7310    0.0420     45.7310  [9.84e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1088    80.3120    0.0738     80.3120  [ 1.73%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob
------------------------------------------------------------------------------------------------------------------------
[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)
------------------------------------------------------------------------------------------------------------------------
 1088    11.7910    0.0108     11.7910  [2.54e-01%] [Thread] tsi::runtime::TsavRT::deallocate
========================================================================================================================
    -  4647.0180    0.0000   4647.0180  [100.00%] TOTAL
========================================================================================================================

Counter Metrics:
------------------------------------------------------------------------------------------------------------------------
Metric                                    Min            Max            Avg
------------------------------------------------------------------------------------------------------------------------
Queue_0_Occupancy                      0.0000         1.0000         0.9725
------------------------------------------------------------------------------------------------------------------------

root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv35_08_22_2025/bin#

The screens are as follows

<img width="1350" height="733" alt="Screenshot 2025-09-03 090921" src="https://github.com/user-attachments/assets/4aacf2da-aa67-46d8-8478-5ff93e3ef521" />
<img width="1351" height="651" alt="Screenshot 2025-09-03 090940" src="https://github.com/user-attachments/assets/f23c73d7-65bb-4b6b-8978-58509b36dbb0" />
