### PR TITLE
@FIR-952: Add uptime to health-check and system-info output

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -780,7 +780,7 @@ def health_check_serial_command():
 
     serial_script.pre_and_post_check(port, baudrate)
 
-    command = f"free -h; df -h; top -b -n1"
+    command = f"uptime; free -h; df -h; top -b -n1"
 
     try:
         result = serial_script.send_serial_command(port, baudrate, command)
@@ -808,7 +808,7 @@ def system_info_serial_command():
 
     serial_script.pre_and_post_check(port, baudrate)
 
-    command = f"{exe_path}../install/tsi-version;lsmod; lscpu; lsblk"
+    command = f"{exe_path}../install/tsi-version; uptime; lsmod; lscpu; lsblk"
 
     try:
         result = serial_script.send_serial_command(port, baudrate, command)


### PR DESCRIPTION
The test results are as follows

<img width="1197" height="962" alt="Screenshot 2025-09-09 at 5 38 42 PM" src="https://github.com/user-attachments/assets/1ec945f4-243a-4c16-8eed-a561cbb4112f" />
<img width="1197" height="962" alt="Screenshot 2025-09-09 at 5 38 20 PM" src="https://github.com/user-attachments/assets/c2d9cf25-a030-4c7e-b1e6-1ed8ad74da6d" />
