### PR TITLE
@FIR-956: The model download from huggingface and ollama was not showing right status

### DIFF
--- a/backend/open_webui/routers/ollama.py
+++ b/backend/open_webui/routers/ollama.py
@@ -741,6 +741,11 @@ async def pull_model_helper(
     )
 
 
+async def pull_model_helper_stream(user, key, model_name):
+    result_response = await pull_model_helper(user, key, model_name)
+    yield json.dumps({"result": result_response}) + "\n"
+
+
 @router.post("/api/pull")
 @router.post("/api/pull/{url_idx}")
 async def pull_model(
@@ -765,11 +770,6 @@ async def pull_model(
         user=user,
     )
 
-    async def pull_model_helper_stream(user, key, model_name):
-        yield json.dumps({"status": "IGNORE ABOVE MESSAGE"}) + "\n"
-        result_response = await pull_model_helper(user, key, model_name)
-        yield json.dumps({"result": result_response}) + "\n"
-
     GOLDEN_NAME = None
 
     async def stream():
@@ -788,11 +788,7 @@ async def pull_model(
             async for output in pull_model_helper_stream(user, key, form_data["model"]):
                 yield output  # .encode()
 
-    async def userInterface():
-        response = StreamingResponse(stream(), media_type="application/json")
-        return response
-
-    return await userInterface()
+    return StreamingResponse(stream(), media_type="application/json")
 
 
 class PushModelForm(BaseModel):


### PR DESCRIPTION
This change handles the hugging face and ollama download. The root cause of the problem was extra yield and unnencessary redirection and await while stream handling when uploading model to FPGA through flask.

The test results are as following, now when the upload to FPGA is finished and down load is complete there is no Cancelled or other status displayed which was confusion earlier.

<img width="1362" height="610" alt="Screenshot 2025-09-10 143807" src="https://github.com/user-attachments/assets/d9d82efc-65bc-40ed-9579-d2913a3a7e77" />
