### PR TITLE
@FIR-959: Fix the custom model upload not giving complete indication

### DIFF
--- a/src/lib/components/admin/Settings/Models/Manage/ManageOllama.svelte
+++ b/src/lib/components/admin/Settings/Models/Manage/ManageOllama.svelte
@@ -328,7 +328,11 @@
 			toast.error(error?.detail ?? error);
 		}
 
-		if (uploaded) {
+		/* Following lines are commented out to ensure when upload is complete the pop up disappears
+		 * in upstream code the createModel is happening twice and it fails here
+		 * as the model already exists created in Ollama.py
+		 */
+		/*if (uploaded) {
 			const res = await createModel(
 				localStorage.token,
 				`${name}:latest`,
@@ -388,7 +392,7 @@
 					}
 				}
 			}
-		}
+		}*/
 
 		modelFileUrl = '';
 


### PR DESCRIPTION
the change fixes the issue where custom model upload never indicated finish this is an upstream issue and I have fixed it by remove the 2nd CreateModel from front end as the CreateModel was being invoked twice in Upload Model once in Ollama.py and once in FrontEnd. the test results are as follows

root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf# ls -ltr
-rw-r--r--    1 root     root     1321082688 Mar  9 12:36 llama3.2:1b.old
lrwxrwxrwx    1 root     root            27 Mar  9 12:39 Llama3.2:1B-1.2B-F32 -> Llama3.2:1B-1.2B-F32:latest
-rw-r--r--    1 root     root     4400979520 Mar  9 12:44 Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root      10007808 Mar  9 12:46 tinyllama-vo-5m-para.gguf
lrwxrwxrwx    1 root     root            34 Mar  9 12:51 TinyLlama:1.1b -> Tiny-Llama-v0.3-FP32-1.1B-F32.gguf
-rw-r--r--    1 root     root     4683073184 Mar  9 13:13 deepseek-r1:7b
-rw-r--r--    1 root     root     637699456 Mar  9 13:15 TinyLlama:latest
-rw-r--r--    1 root     root     4951085024 Mar  9 13:17 Llama3.2:1B-1.2B-F32:latest
-rw-r--r--    1 root     root      10007808 Mar  9 13:34 Maykeye_test:latest
-rw-r--r--    1 root     root      10007808 Mar  9  2018 MayKeye:latest
-rw-r--r--    1 root     root     1117320512 Mar  9  2018 deepseek-r1:1.5b
drwxr-xr-x    7 root     root          4096 Mar 10  2018 hf.co
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 karar-test-d45
-rw-r--r--    1 root     root     1321082688 Mar 10  2018 llama3.2:1b
root@agilex7_dk_si_agf014ea:/tsi/proj/model-cache/gguf#

Flask Logs
======================================
 Running on system: fpga3
======================================
Valid system.. continuing setup
Found PCI device at BDF: 0000:04:00.0
Removing PCI device: 0000:04:00.0
Rescanning PCI bus...
Dumping PCI data using script: /aws/proj/rel/sw/platform/release_v0.1.1.tsv026_04_15_2025/scripts/dump-pci.sh setpci -s1:0 VENDOR_ID
15b7
 setpci -s1:0 DEVICE_ID
5017
 setpci -s1:0 REVISION
02
setpci -s1:0 CLASS_DEVICE
0108
setpci -s1:0 SUBSYSTEM_VENDOR_ID
15b7
 setpci -s1:0 SUBSYSTEM_ID
5017
 setpci -s1:0 BASE_ADDRESS_0
f6f00004
setpci -s1:0 BASE_ADDRESS_1
00000000
setpci -s1:0 BASE_ADDRESS_2
00000000
setpci -s1:0 BASE_ADDRESS_3
00000000
lspci -vvvnns1:0
01:00.0 Non-Volatile memory controller [0108]: Sandisk Corp Device [15b7:5017] (rev 01) (prog-if 02 [NVM Express])
	Subsystem: Sandisk Corp Device [15b7:5017]
	Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx+
	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
	Latency: 0, Cache Line Size: 64 bytes
	Interrupt: pin A routed to IRQ 50
	IOMMU group: 12
	Region 0: Memory at f6f00000 (64-bit, non-prefetchable) [size=16K]
	Capabilities: [80] Power Management version 3
		Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0-,D1-,D2-,D3hot-,D3cold-)
		Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
	Capabilities: [90] MSI: Enable- Count=1/32 Maskable- 64bit+
		Address: 0000000000000000  Data: 0000
	Capabilities: [b0] MSI-X: Enable+ Count=65 Masked-
		Vector table: BAR=0 offset=00003000
		PBA: BAR=0 offset=00002000
	Capabilities: [c0] Express (v2) Endpoint, MSI 00
		DevCap:	MaxPayload 512 bytes, PhantFunc 0, Latency L0s <1us, L1 unlimited
			ExtTag- AttnBtn- AttnInd- PwrInd- RBE+ FLReset+ SlotPowerLimit 0.000W
		DevCtl:	CorrErr+ NonFatalErr+ FatalErr+ UnsupReq+
			RlxdOrd+ ExtTag- PhantFunc- AuxPwr- NoSnoop+ FLReset-
			MaxPayload 512 bytes, MaxReadReq 512 bytes
		DevSta:	CorrErr+ NonFatalErr- FatalErr- UnsupReq+ AuxPwr- TransPend-
		LnkCap:	Port #0, Speed 16GT/s, Width x4, ASPM L1, Exit Latency L1 <8us
			ClockPM+ Surprise- LLActRep- BwNot- ASPMOptComp+
		LnkCtl:	ASPM Disabled; RCB 64 bytes, Disabled- CommClk+
			ExtSynch- ClockPM- AutWidDis- BWInt- AutBWInt-
		LnkSta:	Speed 16GT/s (ok), Width x4 (ok)
			TrErr- Train- SlotClk+ DLActive- BWMgmt- ABWMgmt-
		DevCap2: Completion Timeout: Range B, TimeoutDis+ NROPrPrP- LTR+
			 10BitTagComp+ 10BitTagReq- OBFF Not Supported, ExtFmt+ EETLPPrefix-
			 EmergencyPowerReduction Not Supported, EmergencyPowerReductionInit-
			 FRS- TPHComp- ExtTPHComp-
			 AtomicOpsCap: 32bit- 64bit- 128bitCAS-
		DevCtl2: Completion Timeout: 50us to 50ms, TimeoutDis- LTR+ OBFF Disabled,
			 AtomicOpsCtl: ReqEn-
		LnkCap2: Supported Link Speeds: 2.5-16GT/s, Crosslink- Retimer+ 2Retimers+ DRS-
		LnkCtl2: Target Link Speed: 16GT/s, EnterCompliance- SpeedDis-
			 Transmit Margin: Normal Operating Range, EnterModifiedCompliance- ComplianceSOS-
			 Compliance De-emphasis: -6dB
		LnkSta2: Current De-emphasis Level: -3.5dB, EqualizationComplete+ EqualizationPhase1+
			 EqualizationPhase2+ EqualizationPhase3+ LinkEqualizationRequest-
			 Retimer- 2Retimers- CrosslinkRes: unsupported
	Capabilities: [100 v2] Advanced Error Reporting
		UESta:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
		UEMsk:	DLP- SDES- TLP- FCP- CmpltTO- CmpltAbrt- UnxCmplt- RxOF- MalfTLP- ECRC- UnsupReq- ACSViol-
		UESvrt:	DLP+ SDES- TLP- FCP+ CmpltTO- CmpltAbrt- UnxCmplt- RxOF+ MalfTLP+ ECRC- UnsupReq- ACSViol-
		CESta:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr-
		CEMsk:	RxErr- BadTLP- BadDLLP- Rollover- Timeout- AdvNonFatalErr+
		AERCap:	First Error Pointer: 00, ECRCGenCap+ ECRCGenEn- ECRCChkCap+ ECRCChkEn-
			MultHdrRecCap- MultHdrRecEn- TLPPfxPres- HdrLogCap-
		HeaderLog: 00000000 00000000 00000000 00000000
	Capabilities: [1b8 v1] Latency Tolerance Reporting
		Max snoop latency: 1048576ns
		Max no snoop latency: 1048576ns
	Capabilities: [300 v1] Secondary PCI Express
		LnkCtl3: LnkEquIntrruptEn- PerformEqu-
		LaneErrStat: 0
	Capabilities: [900 v1] L1 PM Substates
		L1SubCap: PCI-PM_L1.2+ PCI-PM_L1.1+ ASPM_L1.2+ ASPM_L1.1- L1_PM_Substates+
			  PortCommonModeRestoreTime=32us PortTPowerOnTime=10us
		L1SubCtl1: PCI-PM_L1.2- PCI-PM_L1.1- ASPM_L1.2- ASPM_L1.1-
			   T_CommonMode=0us LTR1.2_Threshold=32768ns
		L1SubCtl2: T_PwrOn=10us
	Capabilities: [910 v1] Data Link Feature <?>
	Capabilities: [920 v1] Lane Margining at the Receiver <?>
	Capabilities: [9c0 v1] Physical Layer 16.0 GT/s <?>
	Kernel driver in use: nvme
	Kernel modules: nvme

Setting PCI command bit for device: 0000:04:00.0
sudo ./copy2fpga-x86 /proj/work/atrivedi/workspace/09_10_2025/open-webui/backend/open_webui/data/uploads/Maykeye_test.gguf PCIE base address is: 0xfcf0000000
Compressing the .gguf file using gzip before transfer Updated input_file to gzipped version: /proj/work/atrivedi/workspace/09_10_2025/open-webui/backend/open_webui/data/uploads/Maykeye_test.gguf.gz

BEGIN FILE TRANSFER (Send process):
====================================
On FPGA Target, Start Receive process. After it has started, press a key <'y/Y'>: File size to be transfered: 7130385 bytes

Starting Transfer >>>>>>
Current time: 11:09:04
Current date: 2025-09-11
Waiting for receive/reader process to complete... \ Time taken for transfer: 0.456117 seconds
Current time: 11:09:05
Current date: 2025-09-11

File Transfer completed.

The UI logs are here

<img width="1879" height="1227" alt="Screenshot 2025-09-11 110828" src="https://github.com/user-attachments/assets/68d6b4a9-c8a8-468f-b248-1ea5b70c70a9" />
<img width="1875" height="1223" alt="Screenshot 2025-09-11 110853" src="https://github.com/user-attachments/assets/375a8d16-3130-465d-ab20-d81fd4a928bb" />
<img width="1871" height="1220" alt="Screenshot 2025-09-11 110906" src="https://github.com/user-attachments/assets/aa2fcc71-b6d3-41f6-8dd6-c05af4725158" />
<img width="1877" height="1223" alt="Screenshot 2025-09-11 110918" src="https://github.com/user-attachments/assets/c4f21811-ccc4-4c50-9464-f4913aa0c192" />
<img width="1875" height="1223" alt="Screenshot 2025-09-11 110939" src="https://github.com/user-attachments/assets/595c78c6-0042-422c-8b76-bbba47d93cd0" />
