### PR TITLE
@FIR-966: Change pre and post check to not use trash

### DIFF
--- a/backend/open_webui/routers/flaskIfc/serial_script.py
+++ b/backend/open_webui/routers/flaskIfc/serial_script.py
@@ -322,9 +322,9 @@ def pre_and_post_check(port, baudrate):
     flag = ["ok"]
     ser = serial.Serial(port, baudrate)
 
-    ser.write(("trash" + "\n").encode())
+    ser.write(("\n").encode())
     time.sleep(0.1)
-    ser.write(("trash" + "\n").encode())
+    ser.write(("\n").encode())
     while True:
         line = b""
         while True:
@@ -344,23 +344,28 @@ def pre_and_post_check(port, baudrate):
                 ser.close()
                 return "Program interrupted by user"
 
-        if "ogin incorrec" in line.decode("utf-8", errors="replace"):
+        decoded_line = line.decode("utf-8", errors="replace")
+        if "agilex7_dk_si_agf014ea login:" in decoded_line:
             time.sleep(0.1)
             flag[0] = "root issue"
+            print("root issue")
             break
-        elif "nknown command 'trash'" in line.decode("utf-8", errors="replace"):
+        elif "SOCFPGA_AGILEX7" in decoded_line:
             time.sleep(0.1)
             flag[0] = "boot issue"
+            print("boot issue")
             break
-        elif "trash: command" in line.decode("utf-8", errors="replace"):
+        elif "@agilex7_dk_si_agf014ea:" in decoded_line:
             time.sleep(0.1)
             break
+
     ser.close()
     if flag[0] == "root issue":
         ser = serial.Serial(port, baudrate)
         time.sleep(0.1)
         ser.write(("root" + "\n").encode())
         time.sleep(0.1)
+        check_for_prompt(ser, 3)
         ser.close()
     elif flag[0] == "boot issue":
         explicit_boot_command(port, baudrate)


### PR DESCRIPTION
This change has following
1. use new line instead of "trash" to getect different cases
2. When login prompt is detected enter root password and wait for prompt
3. When boot prompt is detected keep original handling
4. Look for right parmer after each use case.

the test results are as follows
Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My name is'}], 'stream': True} root issue
Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000Tim and his dog, Spot. They want to play together. Tim says, \"Let's\n\n\n\n", "thinking": "\u0000Tim and his dog, Spot. They want to play together. Tim says, \"Let's\n\n\n\n", "tool_calls": null, "openai_tool_calls": null, "meta": "   sampling time =     456.21 ms /    24 runs   (   19.01 ms per token,    52.61 tokens per second)\nllama_perf_context_print:        load time =    1435.67 ms\nllama_perf_context_print: prompt eval time =     177.61 ms /     4 tokens (   44.40 ms per token,    22.52 tokens per second)\nllama_perf_context_print:        eval time =    1542.99 ms /    19 runs   (   81.21 ms per token,    12.31 tokens per second)\nllama_perf_context_print:       total time =    3481.90 ms /    23 tokens\n\n=== GGML Perf Summary ===\nOp                   Runs        Total us            Avg us\nADD                   320          235947            737.33\nMUL                   500          398124            796.25\nRMS_NORM             1068            3227              3.02\nMUL_MAT              4746         2829232            596.13\nCPY                  1011            4463              4.41\nCONT                  425            1097              2.58\nRESHAPE              1303            1028              0.79\nVIEW                 1220             775              0.64\nPERMUTE              1191             841              0.71\nTRANSPOSE             328             235              0.72\nGET_ROWS              152             922              6.07\nSOFT_MAX              504           26921             53.41\nROPE                  838            4330              5.17\nUNARY                 160          107967            674.79\n-> SILU             160          107967            674.79\n[2018-03-09 13:04:09.147905] 327:328 [\u001b[31m\u001b[1merror\u001b[m]  :: </proj/work/dreddy/txe_changes/tsi-apc-manager/platform/rsm_mgr/txe_alloc_release.c:153> Invalid request count (0), must be between 1 and 4096\n\nOPU Profiling Results:\n------------------------------------------------------------------------------------------------------------------------\nCalls  Total(ms)    T/call    Self(ms)  Function\n------------------------------------------------------------------------------------------------------------------------\n1    20.2480   20.2480      1.1410  [4.59e-01%] [Thread] OPU\n1    19.1070   19.1070     17.5510  \u2514\u2500 [4.33e-01%] tsi::runtime::TsavRTFPGA::initialize\n1     0.8000    0.8000      0.8000    \u2514\u2500 [1.81e-02%] tsi::runtime::TsavRTFPGA::initializeQueues\n1     0.5700    0.5700      0.5700    \u2514\u2500 [1.29e-02%] tsi::runtime::TsavRT::initialize\n1     0.1860    0.1860      0.1290    \u2514\u2500 [4.22e-03%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand\n2     0.0570    0.0285      0.0570      \u2514\u2500 [1.29e-03%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   217.0790    0.1995      0.0000  [ 4.92%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion\n1088  4321.7474    3.9722   4321.7474  \u2514\u2500 [97.96%] TXE 0 Idle\n566   119.4940    0.2111    119.4940  \u2514\u2500 [ 2.71%] [ txe_mult ]\n362    71.7060    0.1981     71.7060  \u2514\u2500 [ 1.63%] [ txe_add ]\n160    40.6405    0.2540     40.6405  \u2514\u2500 [9.21e-01%] [ txe_silu ]\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   117.0900    0.1076    110.2330  [ 2.65%] [Thread] tsi::runtime::TsavRT::finalizeCommandList\n1088     6.8570    0.0063      6.8570  \u2514\u2500 [1.55e-01%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   225.9040    0.2076     26.8820  [ 5.12%] [Thread] tsi::runtime::TsavRT::processResponses\n1088   199.0220    0.1829    199.0220  \u2514\u2500 [ 4.51%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1    35.5640   35.5640     34.3490  [8.06e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize\n1     1.2150    1.2150      1.2150  \u2514\u2500 [2.75e-02%] tsi::runtime::TsavRTFPGA::releaseTxes\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1089    14.5400    0.0134     14.5400  [3.30e-01%] [Thread] tsi::runtime::TsavRT::allocate\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   162.3890    0.1493    162.3890  [ 3.68%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088    38.0160    0.0349     38.0160  [8.62e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088    80.3500    0.0739     80.3500  [ 1.82%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088    11.4990    0.0106     11.4990  [2.61e-01%] [Thread] tsi::runtime::TsavRT::deallocate\n========================================================================================================================\n-  4411.8360    0.0000   4411.8360  [100.00%] TOTAL\n========================================================================================================================\n\nCounter Metrics:\n------------------------------------------------------------------------------------------------------------------------\nMetric                                    Min            Max            Avg\n------------------------------------------------------------------------------------------------------------------------\nQueue_0_Occupancy                      0.0000         1.0000         0.9798\n------------------------------------------------------------------------------------------------------------------------\n\n"}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

127.0.0.1 - - [16/Sep/2025 10:46:06] "POST /api/chat HTTP/1.1" 200 -

Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My name is'}], 'stream': True} boot issue
SERIAL/TARGET:## Loading kernel from FIT Image at 02000000 ... SERIAL/TARGET:Using 'conf' configuration
SERIAL/TARGET:Verifying Hash Integrity ... OK
SERIAL/TARGET:Trying 'kernel' kernel subimage
SERIAL/TARGET:Description:  Linux Kernel
SERIAL/TARGET:Type:         Kernel Image
SERIAL/TARGET:Compression:  lzma compressed
SERIAL/TARGET:Data Start:   0x02000148
SERIAL/TARGET:Data Size:    10157098 Bytes = 9.7 MiB
SERIAL/TARGET:Architecture: AArch64
SERIAL/TARGET:OS:           Linux
SERIAL/TARGET:Load Address: 0x06000000
SERIAL/TARGET:Entry Point:  0x06000000
SERIAL/TARGET:Hash algo:    crc32
SERIAL/TARGET:Hash value:   36f7070b
SERIAL/TARGET:Verifying Hash Integrity ... crc32+ OK
SERIAL/TARGET:## Loading fdt from FIT Image at 02000000 ...
SERIAL/TARGET:Using 'conf' configuration
SERIAL/TARGET:Verifying Hash Integrity ... OK
SERIAL/TARGET:Trying 'fdt' fdt subimage
SERIAL/TARGET:Description:  Linux DTB
SERIAL/TARGET:Type:         Flat Device Tree
SERIAL/TARGET:Compression:  uncompressed
SERIAL/TARGET:Data Start:   0x029afe14
..
..
SERIAL/TARGET:
SERIAL/TARGET:Poky (Yocto Project Reference Distro) 5.2.3 agilex7_dk_si_agf014ea ttyS0
Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000|||||||   ||||||||\n|||||   |||||\n|||   |||\n|\n\n", "thinking": "\u0000|||||||   ||||||||\n|||||   |||||\n|||   |||\n|\n\n", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

127.0.0.1 - - [16/Sep/2025 10:50:41] "POST /api/chat HTTP/1.1" 200 - Request: {'model': 'MayKeye:latest', 'messages': [{'role': 'user', 'content': 'My name is'}], 'stream': True} Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000Sue. Sue liked to play with her friends in the park. One day, she saw a big\n\n\n\n", "thinking": "\u0000Sue. Sue liked to play with her friends in the park. One day, she saw a big\n\n\n\n", "tool_calls": null, "openai_tool_calls": null, "meta": "   sampling time =     459.15 ms /    24 runs   (   19.13 ms per token,    52.27 tokens per second)\nllama_perf_context_print:        load time =    1696.25 ms\nllama_perf_context_print: prompt eval time =     198.42 ms /     4 tokens (   49.60 ms per token,    20.16 tokens per second)\nllama_perf_context_print:        eval time =    1511.56 ms /    19 runs   (   79.56 ms per token,    12.57 tokens per second)\nllama_perf_context_print:       total time =    3715.30 ms /    23 tokens\n\n=== GGML Perf Summary ===\nOp                   Runs        Total us            Avg us\nADD                   320          234299            732.18\nMUL                   500          396107            792.21\nRMS_NORM             1111            7297              6.57\nMUL_MAT              4824         2906129            602.43\nCPY                  1027            8540              8.32\nCONT                  409            1034              2.53\nRESHAPE              1355            2123              1.57\nVIEW                 1199             767              0.64\nPERMUTE              1166             809              0.69\nTRANSPOSE             331             260              0.79\nGET_ROWS              156            4682             30.01\nSOFT_MAX              541           33569             62.05\nROPE                  802           10506             13.10\nUNARY                 160          107009            668.81\n-> SILU             160          107009            668.81\n[2018-03-09 12:36:02.913272] 328:329 [\u001b[31m\u001b[1merror\u001b[m]  :: </proj/work/dreddy/txe_changes/tsi-apc-manager/platform/rsm_mgr/txe_alloc_release.c:153> Invalid request count (0), must be between 1 and 4096\n\nOPU Profiling Results:\n------------------------------------------------------------------------------------------------------------------------\nCalls  Total(ms)    T/call    Self(ms)  Function\n------------------------------------------------------------------------------------------------------------------------\n1    46.6470   46.6470      8.2720  [ 1.03%] [Thread] OPU\n1    38.3750   38.3750     29.6710  \u2514\u2500 [8.45e-01%] tsi::runtime::TsavRTFPGA::initialize\n1     3.6980    3.6980      3.6980    \u2514\u2500 [8.15e-02%] tsi::runtime::TsavRTFPGA::initializeQueues\n1     2.6090    2.6090      2.6090    \u2514\u2500 [5.75e-02%] tsi::runtime::TsavRT::initialize\n1     2.3970    2.3970      2.0760    \u2514\u2500 [5.28e-02%] tsi::runtime::TsavRTFPGA::sendNOPTestCommand\n2     0.3210    0.1605      0.3210      \u2514\u2500 [7.07e-03%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::awaitCommandListCompletion (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   216.6890    0.1992      0.0000  [ 4.77%] [Thread] tsi::runtime::TsavRT::awaitCommandListCompletion\n1088  4513.3344    4.1483   4513.3344  \u2514\u2500 [99.42%] TXE 0 Idle\n566   119.4386    0.2110    119.4386  \u2514\u2500 [ 2.63%] [ txe_mult ]\n362    71.5906    0.1978     71.5906  \u2514\u2500 [ 1.58%] [ txe_add ]\n160    40.6411    0.2540     40.6411  \u2514\u2500 [8.95e-01%] [ txe_silu ]\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::finalizeCommandList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   108.5340    0.0998    101.6720  [ 2.39%] [Thread] tsi::runtime::TsavRT::finalizeCommandList\n1088     6.8620    0.0063      6.8620  \u2514\u2500 [1.51e-01%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::processResponses (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   217.1870    0.1996     22.5640  [ 4.78%] [Thread] tsi::runtime::TsavRT::processResponses\n1088   194.6230    0.1789    194.6230  \u2514\u2500 [ 4.29%] tsi::runtime::executeWithTimeout\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::finalize (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1    37.6600   37.6600     35.1740  [8.30e-01%] [Thread] tsi::runtime::TsavRTFPGA::finalize\n1     2.4860    2.4860      2.4860  \u2514\u2500 [5.48e-02%] tsi::runtime::TsavRTFPGA::releaseTxes\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::allocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1089    14.9760    0.0138     14.9760  [3.30e-01%] [Thread] tsi::runtime::TsavRT::allocate\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::loadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088   164.1560    0.1509    164.1560  [ 3.62%] [Thread] tsi::runtime::TsavRTFPGA::loadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::addCommandToList (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088    38.9400    0.0358     38.9400  [8.58e-01%] [Thread] tsi::runtime::TsavRT::addCommandToList\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRTFPGA::unloadBlob (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088    79.9350    0.0735     79.9350  [ 1.76%] [Thread] tsi::runtime::TsavRTFPGA::unloadBlob\n------------------------------------------------------------------------------------------------------------------------\n[Thread] tsi::runtime::TsavRT::deallocate (cumulative over all threads)\n------------------------------------------------------------------------------------------------------------------------\n1088    11.7350    0.0108     11.7350  [2.59e-01%] [Thread] tsi::runtime::TsavRT::deallocate\n========================================================================================================================\n-  4539.6340    0.0000   4539.6340  [100.00%] TOTAL\n========================================================================================================================\n\nCounter Metrics:\n------------------------------------------------------------------------------------------------------------------------\nMetric                                    Min            Max            Avg\n------------------------------------------------------------------------------------------------------------------------\nQueue_0_Occupancy                      0.0000         1.0000         0.9881\n------------------------------------------------------------------------------------------------------------------------\n\n"}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

127.0.0.1 - - [16/Sep/2025 10:51:16] "POST /api/chat HTTP/1.1" 200 -

The command prompt history is here
root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv35_08_22_2025/bin# root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv35_08_22_2025/bin# root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv35_08_22_2025/bin# history
    1  history -w
    2  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "My name is" 20 MayKeye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
    3  logout
    4  yKeye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
    5  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "My name is" 20 MayKeye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
    6  logout
    7  Keye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
    8  logout
    9  logout
   10  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "My name is" 20 MayKeye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
   11  logout
   12  Keye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
   13  logout
   14  Keye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
   15  logout
   16  logout
   17  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "My name is" 20 MayKeye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
   18  Keye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
   19  reset
   20  logout
   21  logout
   22  cd /usr/bin/tsi/v0.1.1*/bin/; ./run_llama_cli.sh "My name is" 20 MayKeye:latest tSavorite 1.1 512 4 0.9 64 2048 0.8
   23  history
root@agilex7_dk_si_agf014ea:/usr/bin/tsi/v0.1.1.tsv35_08_22_2025/bin#

The screens are as follows
<img width="1792" height="944" alt="Screenshot 2025-09-16 104655" src="https://github.com/user-attachments/assets/9e7b6d5b-7d6d-4688-a1ad-b76d95c94506" />
<img width="1780" height="938" alt="Screenshot 2025-09-16 105129" src="https://github.com/user-attachments/assets/3885f49c-4b18-4feb-8384-779187e78aaa" />
<img width="1785" height="936" alt="Screenshot 2025-09-16 105139" src="https://github.com/user-attachments/assets/43a78d47-ef2e-4356-86c8-5c4584d6f81c" />
<img width="1784" height="941" alt="Screenshot 2025-09-16 111304" src="https://github.com/user-attachments/assets/ef13d8ca-ef12-46ca-b66f-132b22c768ba" />

