### PR TITLE
@FIR-976: This change add abiility to access Xterm via Open-WebUI

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskXterm.py
+++ b/backend/open_webui/routers/flaskIfc/flaskXterm.py
@@ -2,8 +2,8 @@ from flask import Flask
 from flask_terminal import terminal_blueprint, configure_logger
 
 
-app = Flask(__name__)
-app.logger = configure_logger("flask_terminal")
+app = Flask("flaskXterm")
+app.logger = configure_logger("flaskXterm")
 
 app.config["SECRET_KEY"] = "your_secret_key_here"
 
@@ -41,4 +41,8 @@ def is_authenticated():
 app.register_blueprint(terminal_blueprint, url_prefix="/terminal")
 
 if __name__ == "__main__":
-    app.run(port=8080)
+    app.run(
+        ssl_context=("../../../../cert.pem", "../../../../key.pem"),
+        host="0.0.0.0",
+        port=5000,
+    )

--- a/backend/open_webui/routers/flaskIfc/run_flask.sh
+++ b/backend/open_webui/routers/flaskIfc/run_flask.sh
@@ -23,7 +23,8 @@ pip install flask-terminal
 pip install portalocker
 
 # Run the flaskIfc server
-sudo python3 flaskIfc.py 
+sudo python3 flaskIfc.py &
+flask -A flaskXterm.py --debug run --port 5000 --host 0.0.0.0  --cert=../../../../cert.pem --key=../../../../key.pem &
 #sudo -b flask flaskIfc.py --debug run --port 5003 --host=0.0.0.0
 
 

--- a/src/lib/components/layout/Sidebar/TerminalModal.svelte
+++ b/src/lib/components/layout/Sidebar/TerminalModal.svelte
@@ -1,0 +1,17 @@
+<!-- TerminalModal.svelte -->
+<script lang="ts">
+	export let show = false;
+	export let onClose = () => {};
+	export let url = 'https://localhost:5000'; // default fallback
+</script>
+
+{#if show}
+	<div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+		<div class="bg-white dark:bg-gray-900 rounded-lg p-4 w-[90%] h-[90%] relative">
+			<button class="absolute top-2 right-2 text-gray-500 hover:text-gray-800" on:click={onClose}
+				>X</button
+			>
+			<iframe src={url} class="w-full h-full border-none rounded"></iframe>
+		</div>
+	</div>
+{/if}

--- a/src/lib/components/layout/Sidebar/UserMenu.svelte
+++ b/src/lib/components/layout/Sidebar/UserMenu.svelte
@@ -47,6 +47,18 @@
 	$: if (show) {
 		getUsageInfo();
 	}
+
+	import TerminalModal from './TerminalModal.svelte';
+	let showTerminal = false;
+	let terminalUrl = window.location.origin.replace(':8443', ':5000') + `/terminal`;
+
+	function launchTerminal() {
+		showTerminal = true;
+	}
+
+	function closeTerminal() {
+		showTerminal = false;
+	}
 </script>
 
 <ShortcutsModal bind:show={$showShortcuts} />
@@ -143,6 +155,23 @@
 						<UserGroup className="w-5 h-5" strokeWidth="1.5" />
 					</div>
 					<div class=" self-center truncate">{$i18n.t('Admin Panel')}</div>
+				</DropdownMenu.Item>
+			{/if}
+
+			{#if role === 'admin'}
+				<DropdownMenu.Item
+					as="a"
+					href="#"
+					class="flex rounded-xl py-1.5 px-3 w-full hover:bg-gray-50 dark:hover:bg-gray-800 transition cursor-pointer"
+					on:click={(e) => {
+						e.preventDefault();
+						launchTerminal();
+					}}
+				>
+					<div class="self-center mr-3">
+						<UserGroup className="w-5 h-5" strokeWidth="1.5" />
+					</div>
+					<div class="self-center truncate">{$i18n.t('Launch Terminal')}</div>
 				</DropdownMenu.Item>
 			{/if}
 
@@ -262,3 +291,5 @@
 		</DropdownMenu.Content>
 	</slot>
 </DropdownMenu.Root>
+
+<TerminalModal show={showTerminal} onClose={closeTerminal} url={terminalUrl} />

--- a/src/lib/i18n/locales/en-GB/translation.json
+++ b/src/lib/i18n/locales/en-GB/translation.json
@@ -919,6 +919,7 @@
 	"Last Active": "",
 	"Last Modified": "",
 	"Last reply": "",
+	"Launch Terminal": "",
 	"LDAP": "",
 	"LDAP server updated": "",
 	"Leaderboard": "",

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -919,6 +919,7 @@
 	"Last Active": "",
 	"Last Modified": "",
 	"Last reply": "",
+	"Launch Terminal": "",
 	"LDAP": "",
 	"LDAP server updated": "",
 	"Leaderboard": "",

--- a/src/lib/i18n/locales/fr-CA/translation.json
+++ b/src/lib/i18n/locales/fr-CA/translation.json
@@ -919,6 +919,7 @@
 	"Last Active": "Dernière activité",
 	"Last Modified": "Dernière modification",
 	"Last reply": "Déernière réponse",
+	"Launch Terminal": "Lancer le terminal",
 	"LDAP": "LDAP",
 	"LDAP server updated": "Serveur LDAP mis à jour",
 	"Leaderboard": "Classement",

--- a/src/lib/i18n/locales/fr-FR/translation.json
+++ b/src/lib/i18n/locales/fr-FR/translation.json
@@ -919,6 +919,7 @@
 	"Last Active": "Dernière activité",
 	"Last Modified": "Dernière modification",
 	"Last reply": "Déernière réponse",
+	"Launch Terminal": "Lancer le terminal",
 	"LDAP": "LDAP",
 	"LDAP server updated": "Serveur LDAP mis à jour",
 	"Leaderboard": "Classement",

--- a/src/lib/i18n/locales/ja-JP/translation.json
+++ b/src/lib/i18n/locales/ja-JP/translation.json
@@ -919,6 +919,7 @@
 	"Last Active": "最終アクティブ",
 	"Last Modified": "最終変更",
 	"Last reply": "最終応答",
+	"Launch Terminal": "ターミナルを起動",
 	"LDAP": "LDAP",
 	"LDAP server updated": "LDAPサーバーの更新に成功しました",
 	"Leaderboard": "リーダーボード",


### PR DESCRIPTION
The changes are as follows
1. Run flaskXterm as https://{host_machine}:5000 end point
2. Add a Launch Terminal option to User Setting Menu
3. Add a Modal for XtermJS to execute when Launch Terminal is selected
4. Added translation support for french (france and canada), japanese, english (US and Great Britain)

The test results are as follows

<img width="1680" height="876" alt="Screenshot 2025-09-22 212004" src="https://github.com/user-attachments/assets/583852cc-fc71-4f79-bf5c-4391494aa14f" />
<img width="1685" height="880" alt="Screenshot 2025-09-22 212026" src="https://github.com/user-attachments/assets/9ecbc2bb-7502-47ff-a573-124cea460e40" />
<img width="1683" height="880" alt="Screenshot 2025-09-22 212112" src="https://github.com/user-attachments/assets/c572b6f6-fa38-4d1d-996a-d2fd39c21884" />
<img width="1689" height="885" alt="Screenshot 2025-09-22 212128" src="https://github.com/user-attachments/assets/61d0ca74-7b1e-4a2a-ab20-05d3f05f9e33" />

