### PR TITLE
@FIR-978: Make changes to fit the Xterm in smaller browser windows

### DIFF
--- a/src/lib/components/layout/Sidebar/TerminalModal.svelte
+++ b/src/lib/components/layout/Sidebar/TerminalModal.svelte
@@ -6,10 +6,12 @@
 </script>
 
 {#if show}
-	<div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
-		<div class="bg-white dark:bg-gray-900 rounded-lg p-4 w-[90%] h-[90%] relative">
+	<div class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-[9999]">
+		<div
+			class="bg-white dark:bg-gray-900 rounded-lg p-4 font-mono w-[98ch] h-[32em] relative overflow-hidden"
+		>
 			<button class="absolute top-2 right-2 text-gray-500 hover:text-gray-800" on:click={onClose}
-				>X</button
+				>x</button
 			>
 			<iframe src={url} class="w-full h-full border-none rounded"></iframe>
 		</div>


### PR DESCRIPTION
This change uses default terminal size for Modal to fit in smaller windows

The test results are as follows

<img width="1904" height="1419" alt="Screenshot 2025-09-23 210401" src="https://github.com/user-attachments/assets/15a2be47-f100-487d-98f0-57e6fe59a2dc" />
<img width="1350" height="604" alt="Screenshot 2025-09-23 210443" src="https://github.com/user-attachments/assets/57bc8653-ba9b-485f-bee5-9b6ed030e64e" />
