### PR TITLE
@FIR-1000: First version of Open-WebUI Flask Interface for SSH/QEMU

### DIFF
--- a/backend/open_webui/routers/flaskIfc/serial_script_for_ssh.py
+++ b/backend/open_webui/routers/flaskIfc/serial_script_for_ssh.py
@@ -1,0 +1,397 @@
+import serial
+import sys
+import time
+import portalocker
+import paramiko
+
+SERIAL_LOCK_FILE = "./serial_port.lock"  # Use a lock file
+exe_path = "/usr/bin/tsi/v0.1.1*/bin/"
+
+TXE_HOST = "localhost"
+TXE_PORT = 8000
+TXE_PROMPT = "tsi_apc_prompt>"
+TXE_CLOSE_COMMAND = "close all"
+LINUX_LOGGED_IN_PROMPT = "@agilex7_dk_si_agf014ea"
+LINUX_LOGIN_PROMPT = "agilex7_dk_si_agf014ea"
+QEMU_LOGIN_PROMPT = "qemuarm64"
+QEMU_LOGGED_IN_PROMPT = "@qemuarm64"
+
+# SSH connection details
+hostname = "192.168.7.4"
+username = "root"
+password = "your_password"  # or use key-based auth
+port = 22
+
+
+def is_lock_available():
+    try:
+        with open(SERIAL_LOCK_FILE, "w") as lock_fp:
+            portalocker.lock(lock_fp, portalocker.LOCK_EX | portalocker.LOCK_NB)
+            portalocker.unlock(lock_fp)
+        return True  # Lock was successfully acquired
+    except portalocker.exceptions.LockException:
+        return False  # Lock is already held by another process
+
+
+def check_for_specific_prompt(shell, timeout=10, prompt=LINUX_LOGGED_IN_PROMPT):
+    data = "\0"
+    start = time.time()
+
+    while time.time() - start < timeout:
+        try:
+            line = b""
+            while time.time() - start < timeout:
+                byte = shell.recv(1)  # Read one byte at a time
+                line += byte
+                if byte in [b"\n", b"#", b">"]:  # Stop when delimiter is found
+                    break
+
+            if line:
+                try:
+                    read_next_line = line.decode("utf-8", errors="replace")
+                except UnicodeDecodeError as e:
+                    print("Decoding error:", e, "Raw line:", line)
+                    continue
+
+                if (
+                    prompt in read_next_line.strip()
+                    or QEMU_LOGGED_IN_PROMPT in read_next_line.strip()
+                ):
+                    return True
+            else:
+                return False
+
+        except Exception as e:
+            print(f"Shell read error: {e}")
+            return False
+        except KeyboardInterrupt:
+            return False
+
+    return False
+
+
+def check_for_prompt(shell, timeout=10):
+    data = "\0"
+    first_time = True
+    start = time.time()
+
+    while time.time() - start < timeout:
+        try:
+            line = b""
+            while time.time() - start < timeout:
+                byte = shell.recv(1)  # Read one byte at a time
+                line += byte
+                if byte in [b"\n", b"#", b">"]:  # Stop when delimiter is found
+                    break
+
+            if line:
+                try:
+                    read_next_line = line.decode("utf-8", errors="replace").strip()
+                except UnicodeDecodeError as e:
+                    print("Decoding error:", e, "Raw line:", line)
+                    continue
+
+                if (
+                    "run-platform-done" in read_next_line
+                    or "SOCFPGA_AGILEX7 " in read_next_line
+                    or "Unknown command " in read_next_line
+                    or LINUX_LOGGED_IN_PROMPT in read_next_line
+                    or QEMU_LOGGED_IN_PROMPT in read_next_line
+                    or "imx8mpevk" in read_next_line
+                ):
+                    return True
+
+                if TXE_PROMPT in read_next_line:
+                    shell.send("exit\n")
+                    time.sleep(3)
+                    return True
+
+                if (
+                    "(Yocto Project Reference Distro) 5.2." in read_next_line
+                    and LINUX_LOGIN_PROMPT in read_next_line
+                ) or (LINUX_LOGIN_PROMPT in read_next_line):
+                    time.sleep(3)
+                    shell.send("root\n")
+                    return True
+
+                if first_time:
+                    first_time = False
+                else:
+                    if "read in progress" not in read_next_line:
+                        data += read_next_line + "\n"
+            else:
+                break
+
+        except Exception as e:
+            print(f"Shell read error: {e}")
+            return False
+        except KeyboardInterrupt:
+            return False
+
+    return False
+
+
+def login_to_txe_mgr_and_send_close_all(shell):
+    shell.send(f"telnet {TXE_HOST} {TXE_PORT}\n")
+    if not check_for_specific_prompt(shell, timeout=3, prompt=TXE_PROMPT):
+        return None
+    shell.send(f"{TXE_CLOSE_COMMAND}\n")
+
+
+def clean_up_after_abort(shell):
+    print("Sending Ctrl-C to abort current task...")
+    shell.send("\x03")  # Ctrl-C
+    shell.send("\x03")
+
+    if not check_for_prompt(shell, 10):
+        if not check_for_specific_prompt(shell, timeout=3, prompt=TXE_PROMPT):
+            print("Error: TXE Manager prompt not detected, likely not running")
+        else:
+            print("Warning: TXE Manager prompt detected, sending close all")
+            login_to_txe_mgr_and_send_close_all(shell)
+            if not check_for_prompt(shell, 3):
+                print("Warning: TXE Manager did not respond to 'close all'.")
+    else:
+        login_to_txe_mgr_and_send_close_all(shell)
+        if not check_for_prompt(shell, 3):
+            print("Warning: TXE Manager did not respond to 'close all'.")
+
+    shell.send("cd /usr/bin/tsi/v0.1.1*/bin/\n")
+    shell.send("../install/tsi-start\n")
+
+    print("TXE Manager cleanup and restart successful.")
+    return True
+
+
+def abort_serial_portion(shell):
+    while not is_lock_available():
+        time.sleep(1)
+
+    with open(SERIAL_LOCK_FILE, "w") as lock_fp:
+        portalocker.lock(lock_fp, portalocker.LOCK_EX)
+        try:
+            # shell.reset_output_buffer()
+            # shell.reset_input_buffer()
+
+            shell.send("\x03")  # Ctrl-C
+            clean_up_after_abort(shell)
+
+        finally:
+            portalocker.unlock(lock_fp)
+
+
+def explicit_boot_command(shell):
+    if not is_lock_available():
+        return None
+
+    time.sleep(2)
+    shell.send("boot\n")
+
+
+def explicit_root_command(shell, path):
+    if not is_lock_available():
+        return None
+
+    timeout = 180  # seconds
+    start_time = time.time()
+
+    while time.time() - start_time < timeout:
+        if not is_lock_available():
+            return None
+
+        line = shell.recv(1024).decode("utf-8", errors="replace").strip()
+        print("SERIAL/TARGET:", line)
+
+        if line:
+            if (
+                "(Yocto Project Reference Distro) 5.2." in line
+                and LINUX_LOGIN_PROMPT in line
+            ) or (QEMU_LOGIN_PROMPT in line):
+                time.sleep(3)
+                shell.send("root\n")
+                break
+
+
+def restart_txe_serial_portion(shell, path):
+    explicit_boot_command(shell)
+    explicit_root_command(shell, path)
+
+    time.sleep(3)
+    shell.send(f"cd {path}\n")
+    time.sleep(3)
+
+
+DEFAULT_COMMAND_TIMEOUT = 7200
+
+
+def send_shell_command(shell, command, timeout=DEFAULT_COMMAND_TIMEOUT):
+    if not is_lock_available():
+        return None
+    try:
+        shell.send(command + "\n")
+        data = "\0"
+        first_time = True
+        start = time.time()
+
+        while time.time() - start < timeout:
+            try:
+                line = b""
+                while time.time() - start < timeout:
+                    if not is_lock_available():
+                        return data
+
+                    byte = shell.recv(1)
+                    line += byte
+
+                    # Check for early exit condition
+                    if b"File receive completed" in line:
+                        return data
+
+                    if byte in [b"\n", b"#"]:
+                        break
+                if line:
+                    try:
+                        read_next_line = line.decode("utf-8", errors="replace").strip()
+                    except UnicodeDecodeError as e:
+                        print("Decoding error:", e, "Raw line:", line)
+                        continue
+
+                    if any(
+                        keyword in read_next_line
+                        for keyword in [
+                            "run-platform-done",
+                            "SOCFPGA_AGILEX7 ",
+                            "Unknown command ",
+                            LINUX_LOGGED_IN_PROMPT,
+                            QEMU_LOGGED_IN_PROMPT,
+                            "imx8mpevk",
+                        ]
+                    ):
+                        if first_time:
+                            first_time = False
+                            continue
+                        else:
+                            break
+
+                    if not any(
+                        keyword in read_next_line
+                        for keyword in ["read in progress", "tSavorite"]
+                    ):
+                        data += read_next_line + "\n"
+                else:
+                    break
+
+            except Exception as e:
+                return f"Error reading from shell: {e}"
+            except KeyboardInterrupt:
+                return "Program interrupted by user"
+
+        return data
+
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def pre_and_post_check(shell):
+    if is_lock_available() != True:
+        return None
+
+    flag = ["ok"]
+
+    shell.send("\n")
+    time.sleep(0.1)
+    shell.send("\n")
+
+    while True:
+        line = b""
+        while True:
+            if is_lock_available() != True:
+                return line
+            try:
+                byte = shell.recv(1)  # Read one byte at a time
+                if byte in [b"\n", b"#"]:  # Stop when delimiter is found
+                    break
+                line += byte
+            except Exception as e:
+                return f"Error reading from shell: {e}"
+            except KeyboardInterrupt:
+                return "Program interrupted by user"
+
+        decoded_line = line.decode("utf-8", errors="replace")
+        if ("agilex7_dk_si_agf014ea login:" in decoded_line) or (
+            "qemuarm64 login:" in decoded_line
+        ):
+            time.sleep(0.1)
+            flag[0] = "root issue"
+            print("root issue")
+            break
+        elif "SOCFPGA_AGILEX7" in decoded_line:
+            time.sleep(0.1)
+            flag[0] = "boot issue"
+            print("boot issue")
+            break
+        elif ("@agilex7_dk_si_agf014ea:" in decoded_line) or (
+            "@qemuarm64:" in decoded_line
+        ):
+            time.sleep(0.1)
+            break
+
+    if flag[0] == "root issue":
+        shell.send("root\n")
+        check_for_prompt(shell, 3)
+    elif flag[0] == "boot issue":
+        explicit_boot_command(shell)
+
+
+def connect_to_shell():
+    try:
+        # Create SSH client
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+        # Establish a transport and attempt 'none' authentication
+        transport = paramiko.Transport((hostname, port))
+        transport.connect()
+        transport.auth_none(username=username)
+
+        # Attach the transport to the client
+        ssh._transport = transport
+
+        # Open a shell session
+        shell = ssh.invoke_shell()
+
+        # Wait and read response
+        time.sleep(2)  # wait for command to execute
+        output = shell.recv(1024).decode()
+        print("Response:", output)
+    except Exception as e:
+        print("SSH connection failed:", e)
+    finally:
+        return ssh, shell
+
+
+def disconnect_shell(ssh, shell):
+    try:
+        # Close connection
+        shell.close()
+        ssh.close()
+    except Exception as e:
+        print("SSH disconnection failed:", e)
+
+
+# This script can be run in standalone as well
+if __name__ == "__main__":
+    ssh, shell = connect_to_shell()
+    if len(sys.argv) == 2 and sys.argv[1] == "abort":
+        abort_serial_portion(shell)
+    if len(sys.argv) == 3 and sys.argv[1] == "restart":
+        path = sys.argv[2]
+        restart_txe_serial_portion(shell, path)
+    else:
+        response = send_shell_command(shell, sys.argv[1])
+        print(response)
+    if len(sys.argv) > 3:
+        print("Usage: python script.py <command>")
+    if ssh != None and shell != None:
+        disconnect_shell(ssh, shell)
+    sys.exit(1)


### PR DESCRIPTION
This change adds support for Qemu based machine for Open-WebUI The changes are
1. Add SSH interface instead of Serial interface if the machine is non FPGA
2. Convert all send/recv to handle shell.send/recv
3. Enable passwordless transport for Qemu SSH

the test results are as follows
atrivedi@fpga4:/proj/work/atrivedi/workspace/10_02_2025/open-webui/backend/open_webui/routers/flaskIfc$  * Detected change in '/proj/work/atrivedi/workspace/10_02_2025/open-webui/backend/open_webui/routers/flaskIfc/flaskIfc.py', reloading
 * Restarting with stat Response: Last login: Fri Oct  3 19:35:29 2025 from 192.168.7.3

       Tsavorite Scalable Intelligence

    |||||||||||||||||||||||||||||||||||||
    |||||||||||||||||||||||||||||||||||||
    ||||||                          |||||
    ||||||                          |||||
    |||||||||||||||||   |||||       |||||
    |||||||||||||||||   |||||       |||||
               ||||||   |||||
    ||||||     ||||||   |||||      ||||||
     ||||||||  ||||||   |||||   ||||||||
       ||||||||||||||   ||||||||||||||
          |||||||||||   ||||||||||||
            |||||||||   ||||||||||
              |||||||   ||||||||
                |||||   |||||
                  |||   |||
                        |

root@qemuarm64:~#
 * Debugger is active!
 * Debugger PIN: 202-000-706

Sys Info Result:
; lscpu; lsblk0.1.1*/bin/../install/tsi-version; uptime; lsmod; TSI Software: v0.1.1.tsv36_09_12_2025
Compiled by: TSI Release Manager
Compile Date: Fri Sep 12th, 2025
FPGA Version: SKYLP G0294
RAL Version: SKYLP_G0294
SOF File Version: ia80m-hps.sof version:SKYLP_G0294 AOT Tests Version: sdk-r.0.1.8
TN APC MANAGER Version: 0.6.0
RT Libs Version: rtlib_250807
GGML Version: 0.0.7
19:38:32  up  20:10,  2 users,  load average: 0.75, 0.65, 0.65
Module                  Size  Used by
ipt_REJECT             12288  5
nf_reject_ipv4         12288  1 ipt_REJECT
xt_limit               12288  5
xt_NFLOG               12288  5
nfnetlink_log          16384  5
xt_physdev             12288  10
vxlan                 102400  0
xt_multiport           12288  2
ip_set                 40960  0
nf_conntrack_netlink    36864  0
xt_addrtype            12288  9
xt_nat                 12288  5
xt_tcpudp              12288  18
xt_MASQUERADE          12288  4
xt_mark                12288  33
xt_comment             12288  156
xt_conntrack           12288  29
ip6table_filter        12288  1
ip6table_mangle        12288  1
iptable_mangle         12288  1
ip6table_nat           12288  1
ip6_tables             24576  3 ip6table_filter,ip6table_nat,ip6table_mangle
nft_chain_nat          12288  0
nft_compat             16384  0
iptable_filter         12288  1
iptable_nat            12288  1
ip_tables              24576  3 iptable_filter,iptable_nat,iptable_mangle
x_tables               32768  21 ip6table_filter,xt_conntrack,iptable_filter,ip6table_nat,nft_compat,xt_multiport,xt_NFLOG,xt_tcpudp,xt_addrtype,xt_physdev,xt_nat,xt_comment,ip6_tables,ipt_REJECT,ip_tables,iptable_nat,xt_limit,ip6table_mangle,xt_MASQUERADE,iptable_mangle,xt_mark
sch_fq_codel           16384  1
openvswitch           155648  0
nsh                    12288  1 openvswitch
nf_conncount           16384  1 openvswitch
nf_nat                 40960  6 ip6table_nat,xt_nat,openvswitch,nft_chain_nat,iptable_nat,xt_MASQUERADE
fuse                  143360  1
configfs               40960  1
Architecture:                aarch64
CPU op-mode(s):            32-bit, 64-bit
Byte Order:                Little Endian
CPU(s):                      4
On-line CPU(s) list:       0-3
Vendor ID:                   ARM
Model name:                Cortex-A57
Model:                   0
Thread(s) per core:      1
Core(s) per cluster:     4
Socket(s):               -
Cluster(s):              1
Stepping:                r1p0
BogoMIPS:                125.00
Flags:                   fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
Vulnerabilities:
Gather data sampling:      Not affected
Indirect target selection: Not affected
Itlb multihit:             Not affected
L1tf:                      Not affected
Mds:                       Not affected
Meltdown:                  Not affected
Mmio stale data:           Not affected
Reg file data sampling:    Not affected
Retbleed:                  Not affected
Spec rstack overflow:      Not affected
Spec store bypass:         Vulnerable
Spectre v1:                Mitigation; __user pointer sanitization
Spectre v2:                Vulnerable
Srbds:                     Not affected
Tsa:                       Not affected
Tsx async abort:           Not affected
NAME MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
vda  253:0    0 20.7G  0 disk /

Error: 200
Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000\n/usr/bin/tsi/v0.1.1*/bin/../install/tsi-version; uptime; lsmod;\r; lscpu; lsblk\nTSI Software: v0.1.1.tsv36_09_12_2025\nCompiled by: TSI Release Manager\nCompile Date: Fri Sep 12th, 2025\nFPGA Version: SKYLP G0294\nRAL Version: SKYLP_G0294\nSOF File Version: ia80m-hps.sof version:SKYLP_G0294\nAOT Tests Version: sdk-r.0.1.8\nTN APC MANAGER Version: 0.6.0\nRT Libs Version: rtlib_250807\nGGML Version: 0.0.7\n19:38:32  up  20:10,  2 users,  load average: 0.75, 0.65, 0.65\nModule                  Size  Used by\nipt_REJECT             12288  5\nnf_reject_ipv4         12288  1 ipt_REJECT\nxt_limit               12288  5\nxt_NFLOG               12288  5\nnfnetlink_log          16384  5\nxt_physdev             12288  10\nvxlan                 102400  0\nxt_multiport           12288  2\nip_set                 40960  0\nnf_conntrack_netlink    36864  0\nxt_addrtype            12288  9\nxt_nat                 12288  5\nxt_tcpudp              12288  18\nxt_MASQUERADE          12288  4\nxt_mark                12288  33\nxt_comment             12288  156\nxt_conntrack           12288  29\nip6table_filter        12288  1\nip6table_mangle        12288  1\niptable_mangle         12288  1\nip6table_nat           12288  1\nip6_tables             24576  3 ip6table_filter,ip6table_nat,ip6table_mangle\nnft_chain_nat          12288  0\nnft_compat             16384  0\niptable_filter         12288  1\niptable_nat            12288  1\nip_tables              24576  3 iptable_filter,iptable_nat,iptable_mangle\nx_tables               32768  21 ip6table_filter,xt_conntrack,iptable_filter,ip6table_nat,nft_compat,xt_multiport,xt_NFLOG,xt_tcpudp,xt_addrtype,xt_physdev,xt_nat,xt_comment,ip6_tables,ipt_REJECT,ip_tables,iptable_nat,xt_limit,ip6table_mangle,xt_MASQUERADE,iptable_mangle,xt_mark\nsch_fq_codel           16384  1\nopenvswitch           155648  0\nnsh                    12288  1 openvswitch\nnf_conncount           16384  1 openvswitch\nnf_nat                 40960  6 ip6table_nat,xt_nat,openvswitch,nft_chain_nat,iptable_nat,xt_MASQUERADE\nfuse                  143360  1\nconfigfs               40960  1\nArchitecture:                aarch64\nCPU op-mode(s):            32-bit, 64-bit\nByte Order:                Little Endian\nCPU(s):                      4\nOn-line CPU(s) list:       0-3\nVendor ID:                   ARM\nModel name:                Cortex-A57\nModel:                   0\nThread(s) per core:      1\nCore(s) per cluster:     4\nSocket(s):               -\nCluster(s):              1\nStepping:                r1p0\nBogoMIPS:                125.00\nFlags:                   fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid\nVulnerabilities:\nGather data sampling:      Not affected\nIndirect target selection: Not affected\nItlb multihit:             Not affected\nL1tf:                      Not affected\nMds:                       Not affected\nMeltdown:                  Not affected\nMmio stale data:           Not affected\nReg file data sampling:    Not affected\nRetbleed:                  Not affected\nSpec rstack overflow:      Not affected\nSpec store bypass:         Vulnerable\nSpectre v1:                Mitigation; __user pointer sanitization\nSpectre v2:                Vulnerable\nSrbds:                     Not affected\nTsa:                       Not affected\nTsx async abort:           Not affected\nNAME MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS\nvda  253:0    0 20.7G  0 disk /\n", "thinking": "System Info", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

127.0.0.1 - - [03/Oct/2025 12:38:32] "POST /api/system-info HTTP/1.1" 200 -

Sys Info Result:
; lscpu; lsblk0.1.1*/bin/../install/tsi-version; uptime; lsmod; TSI Software: v0.1.1.tsv36_09_12_2025
Compiled by: TSI Release Manager
Compile Date: Fri Sep 12th, 2025
FPGA Version: SKYLP G0294
RAL Version: SKYLP_G0294
SOF File Version: ia80m-hps.sof version:SKYLP_G0294 AOT Tests Version: sdk-r.0.1.8
TN APC MANAGER Version: 0.6.0
RT Libs Version: rtlib_250807
GGML Version: 0.0.7
19:38:34  up  20:10,  2 users,  load average: 0.75, 0.65, 0.65
Module                  Size  Used by
ipt_REJECT             12288  5
nf_reject_ipv4         12288  1 ipt_REJECT
xt_limit               12288  5
xt_NFLOG               12288  5
nfnetlink_log          16384  5
xt_physdev             12288  10
vxlan                 102400  0
xt_multiport           12288  2
ip_set                 40960  0
nf_conntrack_netlink    36864  0
xt_addrtype            12288  9
xt_nat                 12288  5
xt_tcpudp              12288  18
xt_MASQUERADE          12288  4
xt_mark                12288  33
xt_comment             12288  156
xt_conntrack           12288  29
ip6table_filter        12288  1
ip6table_mangle        12288  1
iptable_mangle         12288  1
ip6table_nat           12288  1
ip6_tables             24576  3 ip6table_filter,ip6table_nat,ip6table_mangle
nft_chain_nat          12288  0
nft_compat             16384  0
iptable_filter         12288  1
iptable_nat            12288  1
ip_tables              24576  3 iptable_filter,iptable_nat,iptable_mangle
x_tables               32768  21 ip6table_filter,xt_conntrack,iptable_filter,ip6table_nat,nft_compat,xt_multiport,xt_NFLOG,xt_tcpudp,xt_addrtype,xt_physdev,xt_nat,xt_comment,ip6_tables,ipt_REJECT,ip_tables,iptable_nat,xt_limit,ip6table_mangle,xt_MASQUERADE,iptable_mangle,xt_mark
sch_fq_codel           16384  1
openvswitch           155648  0
nsh                    12288  1 openvswitch
nf_conncount           16384  1 openvswitch
nf_nat                 40960  6 ip6table_nat,xt_nat,openvswitch,nft_chain_nat,iptable_nat,xt_MASQUERADE
fuse                  143360  1
configfs               40960  1
Architecture:                aarch64
CPU op-mode(s):            32-bit, 64-bit
Byte Order:                Little Endian
CPU(s):                      4
On-line CPU(s) list:       0-3
Vendor ID:                   ARM
Model name:                Cortex-A57
Model:                   0
Thread(s) per core:      1
Core(s) per cluster:     4
Socket(s):               -
Cluster(s):              1
Stepping:                r1p0
BogoMIPS:                125.00
Flags:                   fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
Vulnerabilities:
Gather data sampling:      Not affected
Indirect target selection: Not affected
Itlb multihit:             Not affected
L1tf:                      Not affected
Mds:                       Not affected
Meltdown:                  Not affected
Mmio stale data:           Not affected
Reg file data sampling:    Not affected
Retbleed:                  Not affected
Spec rstack overflow:      Not affected
Spec store bypass:         Vulnerable
Spectre v1:                Mitigation; __user pointer sanitization
Spectre v2:                Vulnerable
Srbds:                     Not affected
Tsa:                       Not affected
Tsx async abort:           Not affected
NAME MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
vda  253:0    0 20.7G  0 disk /

Error: 200
Response:
 {"status": "success", "model": "ollama", "message": {"content": "\u0000\n/usr/bin/tsi/v0.1.1*/bin/../install/tsi-version; uptime; lsmod;\r; lscpu; lsblk\nTSI Software: v0.1.1.tsv36_09_12_2025\nCompiled by: TSI Release Manager\nCompile Date: Fri Sep 12th, 2025\nFPGA Version: SKYLP G0294\nRAL Version: SKYLP_G0294\nSOF File Version: ia80m-hps.sof version:SKYLP_G0294\nAOT Tests Version: sdk-r.0.1.8\nTN APC MANAGER Version: 0.6.0\nRT Libs Version: rtlib_250807\nGGML Version: 0.0.7\n19:38:34  up  20:10,  2 users,  load average: 0.75, 0.65, 0.65\nModule                  Size  Used by\nipt_REJECT             12288  5\nnf_reject_ipv4         12288  1 ipt_REJECT\nxt_limit               12288  5\nxt_NFLOG               12288  5\nnfnetlink_log          16384  5\nxt_physdev             12288  10\nvxlan                 102400  0\nxt_multiport           12288  2\nip_set                 40960  0\nnf_conntrack_netlink    36864  0\nxt_addrtype            12288  9\nxt_nat                 12288  5\nxt_tcpudp              12288  18\nxt_MASQUERADE          12288  4\nxt_mark                12288  33\nxt_comment             12288  156\nxt_conntrack           12288  29\nip6table_filter        12288  1\nip6table_mangle        12288  1\niptable_mangle         12288  1\nip6table_nat           12288  1\nip6_tables             24576  3 ip6table_filter,ip6table_nat,ip6table_mangle\nnft_chain_nat          12288  0\nnft_compat             16384  0\niptable_filter         12288  1\niptable_nat            12288  1\nip_tables              24576  3 iptable_filter,iptable_nat,iptable_mangle\nx_tables               32768  21 ip6table_filter,xt_conntrack,iptable_filter,ip6table_nat,nft_compat,xt_multiport,xt_NFLOG,xt_tcpudp,xt_addrtype,xt_physdev,xt_nat,xt_comment,ip6_tables,ipt_REJECT,ip_tables,iptable_nat,xt_limit,ip6table_mangle,xt_MASQUERADE,iptable_mangle,xt_mark\nsch_fq_codel           16384  1\nopenvswitch           155648  0\nnsh                    12288  1 openvswitch\nnf_conncount           16384  1 openvswitch\nnf_nat                 40960  6 ip6table_nat,xt_nat,openvswitch,nft_chain_nat,iptable_nat,xt_MASQUERADE\nfuse                  143360  1\nconfigfs               40960  1\nArchitecture:                aarch64\nCPU op-mode(s):            32-bit, 64-bit\nByte Order:                Little Endian\nCPU(s):                      4\nOn-line CPU(s) list:       0-3\nVendor ID:                   ARM\nModel name:                Cortex-A57\nModel:                   0\nThread(s) per core:      1\nCore(s) per cluster:     4\nSocket(s):               -\nCluster(s):              1\nStepping:                r1p0\nBogoMIPS:                125.00\nFlags:                   fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid\nVulnerabilities:\nGather data sampling:      Not affected\nIndirect target selection: Not affected\nItlb multihit:             Not affected\nL1tf:                      Not affected\nMds:                       Not affected\nMeltdown:                  Not affected\nMmio stale data:           Not affected\nReg file data sampling:    Not affected\nRetbleed:                  Not affected\nSpec rstack overflow:      Not affected\nSpec store bypass:         Vulnerable\nSpectre v1:                Mitigation; __user pointer sanitization\nSpectre v2:                Vulnerable\nSrbds:                     Not affected\nTsa:                       Not affected\nTsx async abort:           Not affected\nNAME MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS\nvda  253:0    0 20.7G  0 disk /\n", "thinking": "System Info", "tool_calls": null, "openai_tool_calls": null, "meta": null}, "data": {"some_key": "some_value"}, "done_reason": "stop", "done": true}

127.0.0.1 - - [03/Oct/2025 12:38:34] "POST /api/system-info HTTP/1.1" 200 -

Health Check Result:
uptime; free -h; df -h; top -b -n1
19:38:35  up  20:10,  2 users,  load average: 0.75, 0.65, 0.65
total        used        free      shared  buff/cache   available
Mem:           1.9G      545.5M      765.1M       31.2M      625.0M        1.3G
Swap:             0           0           0
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        20G  1.5G   17G   8% /
devtmpfs        967M     0  967M   0% /dev
tmpfs           968M     0  968M   0% /dev/shm
tmpfs           388M   27M  361M   7% /run
tmpfs           968M     0  968M   0% /tmp
tmpfs           1.0M     0  1.0M   0% /run/credentials/systemd-journald.service
tmpfs           1.0M     0  1.0M   0% /run/credentials/systemd-resolved.service
tmpfs           968M  592K  968M   1% /var/volatile
tmpfs           1.0M     0  1.0M   0% /run/credentials/systemd-networkd.service
tmpfs           1.0M     0  1.0M   0% /run/credentials/getty@tty1.service
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/7cb97684-7845-47f6-ae14-cedbb66e38eb/volumes/kubernetes.io~empty-dir/klipper-cache
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/a986c5b6-3abe-4ceb-aae7-c8140e180129/volumes/kubernetes.io~empty-dir/klipper-config
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/a986c5b6-3abe-4ceb-aae7-c8140e180129/volumes/kubernetes.io~empty-dir/tmp
tmpfs           1.9G  4.0K  1.9G   1% /var/lib/kubelet/pods/7cb97684-7845-47f6-ae14-cedbb66e38eb/volumes/kubernetes.io~secret/values
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/a986c5b6-3abe-4ceb-aae7-c8140e180129/volumes/kubernetes.io~empty-dir/klipper-helm
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/7cb97684-7845-47f6-ae14-cedbb66e38eb/volumes/kubernetes.io~empty-dir/klipper-helm
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/a986c5b6-3abe-4ceb-aae7-c8140e180129/volumes/kubernetes.io~empty-dir/klipper-cache
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/7cb97684-7845-47f6-ae14-cedbb66e38eb/volumes/kubernetes.io~empty-dir/tmp
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/7cb97684-7845-47f6-ae14-cedbb66e38eb/volumes/kubernetes.io~empty-dir/klipper-config
tmpfs           1.9G     0  1.9G   0% /var/lib/kubelet/pods/a986c5b6-3abe-4ceb-aae7-c8140e180129/volumes/kubernetes.io~secret/values
tmpfs           170M   12K  170M   1% /var/lib/kubelet/pods/d4cfc36b-5dd6-4d24-bc75-1eb93331a361/volumes/kubernetes.io~projected/kube-api-access-5mtxm
tmpfs           1.9G   12K  1.9G   1% /var/lib/kubelet/pods/b27ef714-f453-4969-8d61-669cf8cf951a/volumes/kubernetes.io~projected/kube-api-access-7q5f9
tmpfs           1.9G   12K  1.9G   1% /var/lib/kubelet/pods/3d7b73af-f153-472f-9a77-54a1303039b1/volumes/kubernetes.io~projected/kube-api-access-mhfl4
tmpfs           1.9G   12K  1.9G   1% /var/lib/kubelet/pods/a986c5b6-3abe-4ceb-aae7-c8140e180129/volumes/kubernetes.io~projected/kube-api-access-cr57h
tmpfs           1.9G   12K  1.9G   1% /var/lib/kubelet/pods/7cb97684-7845-47f6-ae14-cedbb66e38eb/volumes/kubernetes.io~projected/kube-api-access-gqmdk
shm              64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/f408014eb9a7a1d67da3067e5d493c117848c39e51183c958963da8ad46a3456/shm
shm              64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/cc527a517f162fe671afab7bd59f4ac0ecc497850c9fd4bcbd6f83e9fdfa20b4/shm
shm              64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/9d2dab9c30147eba29d277adf744d4d767872a9fe0cd20b0f6a01e33d2095582/shm
shm              64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/fcf3218778b77df50fd44b4d419b41d30f0cd777fc1193463c23d9bdef265305/shm
shm              64M     0   64M   0% /run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/e0c8eac485d3150101c1ed1be4867b59694c71597bbf3441ca7c5c44bf234b73/shm
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/9d2dab9c30147eba29d277adf744d4d767872a9fe0cd20b0f6a01e33d2095582/rootfs
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/fcf3218778b77df50fd44b4d419b41d30f0cd777fc1193463c23d9bdef265305/rootfs
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/f408014eb9a7a1d67da3067e5d493c117848c39e51183c958963da8ad46a3456/rootfs
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/e0c8eac485d3150101c1ed1be4867b59694c71597bbf3441ca7c5c44bf234b73/rootfs
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/cc527a517f162fe671afab7bd59f4ac0ecc497850c9fd4bcbd6f83e9fdfa20b4/rootfs
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/0c4175618920a7a4772913547c6775c38825f91f129af0875886c81bccdba85b/rootfs
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/291687a48ada0649813a9adda0e5e6847074713b192006f0603f677b821da084/rootfs
overlay          20G  1.5G   17G   8% /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/f46bef841906a10c29bcbe852e930e9f75a413fec86354be31236a0cdbe98779/rootfs
tmpfs           1.0M     0  1.0M   0% /run/credentials/serial-getty@ttyAMA0.service
Mem: 1198580K used, 783428K free, 31936K shrd, 98288K buff, 523900K cached
CPU:   4% usr   0% sys   0% nic  95% idle   0% io   0% irq   0% sirq
Load average: 0.69 0.64 0.64 2/272 72713
PID  PPID USER     STAT   VSZ %VSZ %CPU COMMAND
296     1 root     S    2903m 149%   2% /usr/local/bin/k3s server
321   296 root     S    2838m 146%   1% containerd -c /var/lib/rancher/k3s/agent/etc/containerd/config.toml -a /run/k3s/containerd/containerd.sock --state /run/k3s/containerd --root /var/lib/rancher/k3s/agent/containerd
72713 72690 root     R     3476   0%   1% top -b -n1
1323     1 root     S    2142m 110%   0% /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id f408014eb9a7a1d67da3067e5d493c117848c39e51183c958963da8ad46a3456 -address /run/k3s/containerd/containerd.sock
1312     1 root     S    2142m 110%   0% /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id e0c8eac485d3150101c1ed1be4867b59694c71597bbf3441ca7c5c44bf234b73 -address /run/k3s/containerd/containerd.sock
1304     1 root     S    2142m 110%   0% /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id 9d2dab9c30147eba29d277adf744d4d767872a9fe0cd20b0f6a01e33d2095582 -address /run/k3s/containerd/containerd.sock
1322     1 root     S    2070m 106%   0% /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id fcf3218778b77df50fd44b4d419b41d30f0cd777fc1193463c23d9bdef265305 -address /run/k3s/containerd/containerd.sock
1347     1 root     S    2070m 106%   0% /usr/bin/containerd-shim-runc-v2 -namespace k8s.io -id cc527a517f162fe671afab7bd59f4ac0ecc497850c9fd4bcbd6f83e9fdfa20b4 -address /run/k3s/containerd/containerd.sock
261     1 root     S    1897m  97%   0% /usr/bin/containerd
1611  1323 65532    S    1262m  65%   0% /coredns -conf /etc/coredns/Corefile
1652  1312 1000     S    1252m  64%   0% /metrics-server --cert-dir=/tmp --secure-port=10250 --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --kubelet-use-node-status-port --metric-resolution=15s --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WIT
1640  1304 root     S    1235m  63%   0% local-path-provisioner start --config /etc/config/config.json
165     1 systemd- S    83132   4%   0% /usr/lib/systemd/systemd-timesyncd
123     1 root     S    34448   2%   0% /usr/lib/systemd/systemd-journald
171     1 root     S    27116   1%   0% /usr/lib/systemd/systemd-udevd
1     0 root     S    19340   1%   0% {systemd} /sbin/init
72278 72276 root     S    11172   1%   0% sshd-session: root@pts/0
72689 72687 root     S    11172   1%   0% sshd-session: root@pts/1
245     1 systemd- S    10984   1%   0% /usr/lib/systemd/systemd-networkd
164     1 systemd- S     9492   0%   0% /usr/lib/systemd/systemd-resolved
72276     1 root     S     9412   0%   0% sshd-session: root [priv]
72687     1 root     S     9412   0%   0% sshd-session: root [priv]
235     1 root     S     9368   0%   0% /usr/lib/systemd/systemd-logind
72520   168 root     S     9312   0%   0% systemd-userwork: waiting...
72542   168 root     S     9312   0%   0% systemd-userwork: waiting...
72543   168 root     S     9312   0%   0% systemd-userwork: waiting...
168     1 root     S     8724   0%   0% /usr/lib/systemd/systemd-userdbd
230     1 messageb S     7864   0%   0% /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
72690 72689 root     S     4180   0%   0% -sh
72279 72278 root     S     4180   0%   0% -sh
229     1 root     S     3476   0%   0% /usr/sbin/syslogd -n
228     1 root     S     3476   0%   0% /usr/sbin/klogd -n
21325     1 root     S     2304   0%   0% /sbin/agetty -o -- \u --noreset --noclear --keep-baud 115200,57600,38400,9600 - vt220
231     1 root     S     2304   0%   0% /sbin/agetty -o -- \u --noreset --noclear - linux
1447  1312 65535    S      764   0%   0% /pause
1450  1304 65535    S      764   0%   0% /pause
1455  1322 65535    S      764   0%   0% /pause
1477  1323 65535    S      764   0%   0% /pause
1446  1347 65535    S      764   0%   0% /pause
19     2 root     IW       0   0%   0% [rcu_preempt]
50     2 root     SW       0   0%   0% [kcompactd0]
96     2 root     SW       0   0%   0% [jbd2/vda-8]
70027     2 root     IW       0   0%   0% [kworker/3:1-cgr]
26     2 root     SW       0   0%   0% [ksoftirqd/1]
36     2 root     SW       0   0%   0% [ksoftirqd/3]
18     2 root     SW       0   0%   0% [ksoftirqd/0]
31     2 root     SW       0   0%   0% [ksoftirqd/2]
71906     2 root     IW       0   0%   0% [kworker/3:3-eve]
55886     2 root     IW       0   0%   0% [kworker/u19:1-e]
69597     2 root     IW       0   0%   0% [kworker/0:1-eve]
58106     2 root     IW       0   0%   0% [kworker/u17:1-e]
57281     2 root     IW       0   0%   0% [kworker/u18:1-e]
94     2 root     IW<      0   0%   0% [kworker/2:1H-kb]
77     2 root     IW<      0   0%   0% [kworker/1:1H-kb]
111     2 root     IW<      0   0%   0% [kworker/0:1H-kb]
62417     2 root     IW       0   0%   0% [kworker/u20:0-e]
59     2 root     IW<      0   0%   0% [kworker/3:1H-kb]
66607     2 root     IW       0   0%   0% [kworker/u18:3-e]
69086     2 root     IW       0   0%   0% [kworker/u17:0-e]
67026     2 root     IW       0   0%   0% [kworker/u20:2-e]
21     2 root     SW       0   0%   0% [rcu_exp_gp_kthr]
70471     2 root     IW       0   0%   0% [kworker/2:1-cgr]
70995     2 root     IW       0   0%   0% [kworker/1:2-eve]
68239     2 root     IW       0   0%   0% [kworker/u20:1-f]
71559     2 root     IW       0   0%   0% [kworker/2:0-eve]
71814     2 root     IW       0   0%   0% [kworker/u19:2-w]
72     2 root     SW       0   0%   0% [hwrng]
70020     2 root     IW       0   0%   0% [kworker/u18:0-e]
2     0 root     SW       0   0%   0% [kthreadd]
25     2 root     SW       0   0%   0% [migration/1]
30     2 root     SW       0   0%   0% [migration/2]
35     2 root     SW       0   0%   0% [migration/3]
22     2 root     SW       0   0%   0% [migration/0]
69069     2 root     IW       0   0%   0% [kworker/u19:3-e]
14     2 root     IW       0   0%   0% [kworker/u16:1-i]
70827     2 root     IW       0   0%   0% [kworker/u17:2-e]
43     2 root     SW       0   0%   0% [kdevtmpfs]
3     2 root     SW       0   0%   0% [pool_workqueue_]
4     2 root     IW<      0   0%   0% [kworker/R-kvfre]
5     2 root     IW<      0   0%   0% [kworker/R-rcu_g]
6     2 root     IW<      0   0%   0% [kworker/R-sync_]
7     2 root     IW<      0   0%   0% [kworker/R-slub_]
8     2 root     IW<      0   0%   0% [kworker/R-netns]
11     2 root     IW<      0   0%   0% [kworker/0:0H-ev]
12     2 root     IW       0   0%   0% [kworker/u16:0-e]
13     2 root     IW<      0   0%   0% [kworker/R-mm_pe]
15     2 root     IW       0   0%   0% [rcu_tasks_kthre]
16     2 root     IW       0   0%   0% [rcu_tasks_rude_]
17     2 root     IW       0   0%   0% [rcu_tasks_trace]
20     2 root     SW       0   0%   0% [rcu_exp_par_gp_]
23     2 root     SW       0   0%   0% [cpuhp/0]
24     2 root     SW       0   0%   0% [cpuhp/1]
28     2 root     IW<      0   0%   0% [kworker/1:0H-ev]
29     2 root     SW       0   0%   0% [cpuhp/2]
33     2 root     IW<      0   0%   0% [kworker/2:0H-ev]
34     2 root     SW       0   0%   0% [cpuhp/3]
38     2 root     IW<      0   0%   0% [kworker/3:0H-ev]
44     2 root     IW<      0   0%   0% [kworker/R-inet_]
48     2 root     SW       0   0%   0% [oom_reaper]
49     2 root     IW<      0   0%   0% [kworker/R-write]
51     2 root     IW<      0   0%   0% [kworker/R-kbloc]
52     2 root     IW<      0   0%   0% [kworker/R-blkcg]
55     2 root     IW<      0   0%   0% [kworker/R-md]
56     2 root     IW<      0   0%   0% [kworker/R-md_bi]
60     2 root     IW<      0   0%   0% [kworker/R-rpcio]
61     2 root     IW<      0   0%   0% [kworker/R-xprti]
62     2 root     SW       0   0%   0% [kswapd0]
63     2 root     IW<      0   0%   0% [kworker/R-nfsio]
64     2 root     IW<      0   0%   0% [kworker/R-cifsi]
65     2 root     IW<      0   0%   0% [kworker/R-smb3d]
66     2 root     IW<      0   0%   0% [kworker/R-cifsf]
67     2 root     IW<      0   0%   0% [kworker/R-cifso]
68     2 root     IW<      0   0%   0% [kworker/R-defer]
69     2 root     IW<      0   0%   0% [kworker/R-serve]
70     2 root     IW<      0   0%   0% [kworker/R-cfid_]
71     2 root     IW<      0   0%   0% [kworker/R-kthro]
73     2 root     IW<      0   0%   0% [kworker/R-raid5]
74     2 root     IW<      0   0%   0% [kworker/R-dm_bu]
75     2 root     IW<      0   0%   0% [kworker/R-mld]
78     2 root     IW<      0   0%   0% [kworker/R-ipv6_]
79     2 root     IW<      0   0%   0% [kworker/u21:0]
80     2 root     IW<      0   0%   0% [kworker/u22:0]
81     2 root     IW<      0   0%   0% [kworker/u23:0]
82     2 root     IW<      0   0%   0% [kworker/u24:0]
83     2 root     IW<      0   0%   0% [kworker/u25:0]
97     2 root     IW<      0   0%   0% [kworker/R-ext4-]
71085     2 root     IW       0   0%   0% [kworker/1:3-cgr]
71389     2 root     IW       0   0%   0% [kworker/0:2-cgr]
72374     2 root     IW       0   0%   0% [kworker/0:0]
72375     2 root     IW       0   0%   0% [kworker/0:3-cgr]
72473     2 root     IW       0   0%   0% [kworker/3:0-eve]
72685     2 root     IW       0   0%   0% [kworker/2:2]

<img width="1506" height="843" alt="Screenshot 2025-10-03 at 12 47 27 PM" src="https://github.com/user-attachments/assets/ca7319d4-be21-4a6f-94ef-6dcd0c1a7064" />
<img width="1516" height="808" alt="Screenshot 2025-10-03 at 12 47 45 PM" src="https://github.com/user-attachments/assets/e12c4b13-fcee-468d-8faa-2ef93935c859" />
