### PR TITLE
@VP-204: Fix the non 400 status being treated as error.

### DIFF
--- a/backend/open_webui/routers/files.py
+++ b/backend/open_webui/routers/files.py
@@ -343,6 +343,20 @@ def upload_file_handler(
 
         log.debug(f"downstream status={status_code} body={body}")
 
+        parsed_body = None
+        if isinstance(body, str):
+            try:
+                parsed_body = json.loads(body)
+            except json.JSONDecodeError:
+                parsed_body = None
+        elif isinstance(body, dict):
+            parsed_body = body
+
+        # ---- semantic success override ----
+        if isinstance(parsed_body, dict) and parsed_body.get("status") == "success":
+            status_code = 200
+            body = parsed_body
+
         if status_code >= 400:
             raise HTTPException(status_code=status_code, detail=body)
 


### PR DESCRIPTION
The root cause of the traceback is
1. Not all greater than 400 status code as error from /api/uploadpytorchinput as the end point
2. Parse the json body to understand if the file is coming in chunks and handle it json body success

<img width="2770" height="1286" alt="Screenshot 2026-04-16 at 2 32 20 PM" src="https://github.com/user-attachments/assets/6261ce99-c215-48dd-8d5d-b226ba0db722" />
