### PR TITLE
@VP-227: Add support for tsictl oc status, oc policy & hw status

### DIFF
--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -906,7 +906,7 @@ def health_check_serial_command():
 
     pre_and_post_check()
 
-    command = f"uptime; free -h; df -h; top -b -n1"
+    command = f"echo --- tsictl oc show ---; tsictl oc show; echo --- tcictl oc policy show ---; tsictl oc policy show; echo --- tsictl oc hw status 0 ---; tsictl oc hw status 0; echo --- tsictl oc hw status 1 ---; tsictl oc hw status 1; echo --- free -h ---; free -h; echo --- df -h ---; df -h; echo --- top -b -n1 ---; top -b -n1"
 
     try:
         result = send_serial_command(command)
@@ -934,7 +934,7 @@ def system_info_serial_command():
 
     pre_and_post_check()
 
-    command = f"{exe_path}../install/tsi-version; uptime; lsmod; lscpu; lsblk"
+    command = f"echo --- tsi-version ---; source tsi-version; echo --- tsictl oc show ---; tsictl oc show; echo --- uptime ---; uptime; echo --- lsmod ---; lsmod; echo --- lscpu ---; lscpu; echo --- lsblk ---; lsblk"
 
     try:
         result = send_serial_command(command)

--- a/backend/open_webui/routers/flaskIfc/flaskIfc.py
+++ b/backend/open_webui/routers/flaskIfc/flaskIfc.py
@@ -906,7 +906,7 @@ def health_check_serial_command():
 
     pre_and_post_check()
 
-    command = f"echo --- tsictl oc show ---; tsictl oc show; echo --- tcictl oc policy show ---; tsictl oc policy show; echo --- tsictl oc hw status 0 ---; tsictl oc hw status 0; echo --- tsictl oc hw status 1 ---; tsictl oc hw status 1; echo --- free -h ---; free -h; echo --- df -h ---; df -h; echo --- top -b -n1 ---; top -b -n1"
+    command = f"echo --- tsictl oc show ---; tsictl oc show; echo --- tcictl oc policy show ---; tsictl oc policy show; echo --- tsictl oc hw status 0 ---; tsictl oc hw status 0; echo --- tsictl oc hw status 1 ---; tsictl oc hw status 1; echo --- tsictl oc hw details 0 ---; tsictl oc hw details 0; echo --- tsictl oc hw details 1 ---; tsictl oc hw details 1; echo --- free -h ---; free -h; echo --- df -h ---; df -h; echo --- top -b -n1 ---; top -b -n1"
 
     try:
         result = send_serial_command(command)
@@ -934,7 +934,7 @@ def system_info_serial_command():
 
     pre_and_post_check()
 
-    command = f"echo --- tsi-version ---; source tsi-version; echo --- tsictl oc show ---; tsictl oc show; echo --- uptime ---; uptime; echo --- lsmod ---; lsmod; echo --- lscpu ---; lscpu; echo --- lsblk ---; lsblk"
+    command = f"echo --- Version ---; cat /opt/tsi/current/taos-release; echo --- tsictl oc show ---; tsictl oc show; echo --- uptime ---; uptime; echo --- lsmod ---; lsmod; echo --- lscpu ---; lscpu; echo --- lsblk ---; lsblk"
 
     try:
         result = send_serial_command(command)


### PR DESCRIPTION
This change adds display of OC status
The changes are for system-info and health-check endpoints

The test results are as follows

System-Info
[?2004l
--- tsi-version ---
TSI Software:  v0.3.0-rc1
Build stamp:   20260514+git99c137f
Full version:  v0.3.0-rc1+20260514.git99c137f
Compiled by:   TSI Release Manager
Compile date:  Thu May 14 10:23:22 AM PDT 2026
SDK version:   r.0.4.4
APP version:   v0.1.3
GGML version:  0.4.4
--- tsictl oc show ---
OC 0:
oc-id                 : 0
init-done             : yes
va                    : 0xfc832d4f0000
size                  : 1048576
pa                    : 0x000000000d000000
opu_boot_timestamp    : 2026-05-14 17:47:40.575
opu_boot_count        : 1
DB:
agent-id         : 10000
agent_status     : READY
group_identifier : 0
num_allocs       : 0
num_deallocs     : 0
OC 1:
oc-id                 : 1
init-done             : yes
va                    : 0xfc832d3f0000
size                  : 1048576
pa                    : 0x000000000cc00000
opu_boot_timestamp    : 2026-05-14 17:47:42.520
opu_boot_count        : 1
DB:
agent-id         : 10001
agent_status     : READY
group_identifier : 0
num_allocs       : 0
num_deallocs     : 0
--- uptime ---
20:14:23 up  2:29,  3 users,  load average: 0.00, 0.02, 0.00
--- lsmod ---
Module                  Size  Used by
u_dma_buf              61440  0
uio_pdrv_genirq        16384  0
uio                    32768  1 uio_pdrv_genirq
sch_fq_codel           24576  2
binfmt_misc            28672  1
txe                    24576  1
dm_multipath           49152  0
efi_pstore             12288  0
nfnetlink              20480  2
ip_tables              36864  0
x_tables               65536  1 ip_tables
autofs4                57344  2
btrfs                1929216  0
blake2b_generic        24576  0
raid10                 77824  0
raid456               212992  0
async_raid6_recov      24576  1 raid456
async_memcpy           16384  2 raid456,async_raid6_recov
async_pq               16384  2 raid456,async_raid6_recov
async_xor              16384  3 async_pq,raid456,async_raid6_recov
async_tx               16384  5 async_pq,async_memcpy,async_xor,raid456,async_raid6_recov
xor                    12288  2 async_xor,btrfs
xor_neon               16384  1 xor
raid6_pq              110592  4 async_pq,btrfs,raid456,async_raid6_recov
libcrc32c              12288  2 btrfs,raid456
raid1                  61440  0
raid0                  24576  0
crct10dif_ce           12288  1
polyval_ce             12288  0
polyval_generic        12288  1 polyval_ce
ghash_ce               24576  0
sm4                    12288  0
sha2_ce                20480  0
sha256_arm64           24576  1 sha2_ce
sha1_ce                12288  0
virtio_rng             12288  0
aes_neon_bs            24576  0
aes_neon_blk           28672  1 aes_neon_bs
aes_ce_blk             36864  0
aes_ce_cipher          12288  1 aes_ce_blk
--- lscpu ---
Architecture:             aarch64
CPU op-mode(s):         32-bit, 64-bit
Byte Order:             Little Endian
CPU(s):                   4
On-line CPU(s) list:    0-3
Vendor ID:                ARM
Model name:             Cortex-A57
Model:                0
Thread(s) per core:   1
Core(s) per cluster:  4
Socket(s):            -
Cluster(s):           1
Stepping:             r1p0
BogoMIPS:             125.00
Flags:                fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
NUMA:
NUMA node(s):           1
NUMA node0 CPU(s):      0-3
Vulnerabilities:
Gather data sampling:   Not affected
Itlb multihit:          Not affected
L1tf:                   Not affected
Mds:                    Not affected
Meltdown:               Not affected
Mmio stale data:        Not affected
Reg file data sampling: Not affected
Retbleed:               Not affected
Spec rstack overflow:   Not affected
Spec store bypass:      Vulnerable
Spectre v1:             Mitigation; __user pointer sanitization
Spectre v2:             Vulnerable
Srbds:                  Not affected
Tsx async abort:        Not affected
Vmscape:                Not affected
--- lsblk ---
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
vda     253:0    0  200G  0 disk
├─vda1  253:1    0  199G  0 part /
├─vda15 253:15   0   99M  0 part
└─vda16 259:0    0  923M  0 part
vdb     253:16   0  3.4G  0 disk /tsi/tsi-sw
vdc     253:32   0  157M  0 disk /opt/taos/app
vdd     253:48   0  3.6G  0 disk /opt/taos/build-tools

Health Check
[?2004l
--- tsictl oc show ---
OC 0:
oc-id                 : 0
init-done             : yes
va                    : 0xfc832d4f0000
size                  : 1048576
pa                    : 0x000000000d000000
opu_boot_timestamp    : 2026-05-14 17:47:40.575
opu_boot_count        : 1
DB:
agent-id         : 10000
agent_status     : READY
group_identifier : 0
num_allocs       : 0
num_deallocs     : 0
OC 1:
oc-id                 : 1
init-done             : yes
va                    : 0xfc832d3f0000
size                  : 1048576
pa                    : 0x000000000cc00000
opu_boot_timestamp    : 2026-05-14 17:47:42.520
opu_boot_count        : 1
DB:
agent-id         : 10001
agent_status     : READY
group_identifier : 0
num_allocs       : 0
num_deallocs     : 0
--- tcictl oc policy show ---
RSM allocation policy: POLICY_UNRESTRICTED (unrestricted — up to all READY agents per request)
--- tsictl oc hw status 0 ---
OC 0:
status  : OK
va      : 0xfc832d4f0000
size    : 1048576
pa      : 0x000000000d000000
logging : disabled
req_tag : 0x0000000000000000
resp_tag: 0x0000000000000000
--- tsictl oc hw status 1 ---
OC 1:
status  : OK
va      : 0xfc832d3f0000
size    : 1048576
pa      : 0x000000000cc00000
logging : disabled
req_tag : 0x0000000000000000
resp_tag: 0x0000000000000000
--- free -h ---
total        used        free      shared  buff/cache   available
Mem:           3.3Gi       416Mi       113Mi       1.0Mi       3.0Gi       2.9Gi
Swap:          8.0Gi          0B       8.0Gi
--- df -h ---
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           342M  916K  341M   1% /run
/dev/vda1       193G   11G  183G   6% /
tmpfs           1.7G  100K  1.7G   1% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/vdc        147M  130M  5.7M  96% /opt/taos/app
/dev/vdd        3.5G  3.1G  205M  94% /opt/taos/build-tools
/dev/vdb        3.3G  2.9G  263M  92% /tsi/tsi-sw
tmpfs           342M   12K  342M   1% /run/user/0
--- top -b -n1 ---
top - 20:08:50 up  2:23,  3 users,  load average: 0.12, 0.03, 0.01
Tasks: 121 total,   1 running, 120 sleeping,   0 stopped,   0 zombie
%Cpu(s):  2.7 us,  9.5 sy,  0.0 ni, 87.8 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
MiB Mem :   3413.4 total,    113.6 free,    416.5 used,   3065.3 buff/cache
MiB Swap:   8192.0 total,   8192.0 free,      0.0 used.   2996.9 avail Mem

PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND
2068 root      20   0   12184   4864   2944 R  33.3   0.1   0:00.18 top
922 root      20   0    6368   2176   1920 S   5.6   0.1   0:28.16 tnCliSe+
923 root      20   0 1131868   3044   2048 S   5.6   0.1   2:12.19 tsiTXEm+
1 root      20   0   21824  12116   8660 S   0.0   0.3   0:10.65 systemd
2 root      20   0       0      0      0 S   0.0   0.0   0:00.04 kthreadd
3 root      20   0       0      0      0 S   0.0   0.0   0:00.00 pool_wo+
4 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
5 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
6 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
7 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
10 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
12 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
13 root      20   0       0      0      0 I   0.0   0.0   0:00.00 rcu_tas+
14 root      20   0       0      0      0 I   0.0   0.0   0:00.00 rcu_tas+
15 root      20   0       0      0      0 I   0.0   0.0   0:00.00 rcu_tas+
16 root      20   0       0      0      0 S   0.0   0.0   0:00.05 ksoftir+
17 root      20   0       0      0      0 I   0.0   0.0   0:12.27 rcu_pre+
18 root      rt   0       0      0      0 S   0.0   0.0   0:00.06 migrati+
19 root     -51   0       0      0      0 S   0.0   0.0   0:00.00 idle_in+
20 root      20   0       0      0      0 S   0.0   0.0   0:00.00 cpuhp/0
21 root      20   0       0      0      0 S   0.0   0.0   0:00.00 cpuhp/1
22 root     -51   0       0      0      0 S   0.0   0.0   0:00.00 idle_in+
23 root      rt   0       0      0      0 S   0.0   0.0   0:00.05 migrati+
24 root      20   0       0      0      0 S   0.0   0.0   0:00.02 ksoftir+
26 root       0 -20       0      0      0 I   0.0   0.0   0:00.08 kworker+
27 root      20   0       0      0      0 S   0.0   0.0   0:00.00 cpuhp/2
28 root     -51   0       0      0      0 S   0.0   0.0   0:00.00 idle_in+
29 root      rt   0       0      0      0 S   0.0   0.0   0:00.05 migrati+
30 root      20   0       0      0      0 S   0.0   0.0   0:00.02 ksoftir+
32 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
33 root      20   0       0      0      0 S   0.0   0.0   0:00.00 cpuhp/3
34 root     -51   0       0      0      0 S   0.0   0.0   0:00.00 idle_in+
35 root      rt   0       0      0      0 S   0.0   0.0   0:00.05 migrati+
36 root      20   0       0      0      0 S   0.0   0.0   0:00.02 ksoftir+
38 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
39 root      20   0       0      0      0 S   0.0   0.0   0:00.03 kdevtmp+
40 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
41 root      20   0       0      0      0 S   0.0   0.0   0:00.01 kauditd
42 root      20   0       0      0      0 S   0.0   0.0   0:00.00 khungta+
44 root      20   0       0      0      0 S   0.0   0.0   0:00.00 oom_rea+
45 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
46 root      20   0       0      0      0 S   0.0   0.0   0:01.02 kcompac+
47 root      25   5       0      0      0 S   0.0   0.0   0:00.00 ksmd
49 root      39  19       0      0      0 S   0.0   0.0   0:00.00 khugepa+
50 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
51 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
52 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
53 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
54 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
55 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
56 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
57 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
58 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
59 root     -51   0       0      0      0 S   0.0   0.0   0:00.00 watchdo+
60 root       0 -20       0      0      0 I   0.0   0.0   0:00.09 kworker+
61 root      20   0       0      0      0 S   0.0   0.0   0:04.77 kswapd0
63 root      20   0       0      0      0 S   0.0   0.0   0:00.00 ecryptf+
64 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
66 root       0 -20       0      0      0 I   0.0   0.0   0:00.03 kworker+
69 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
70 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
71 root       0 -20       0      0      0 I   0.0   0.0   0:00.03 kworker+
78 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
80 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
84 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
122 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
126 root      20   0       0      0      0 S   0.0   0.0   0:00.03 hwrng
177 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
214 root      20   0       0      0      0 S   0.0   0.0   0:00.24 jbd2/vd+
215 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
284 root      19  -1   66684  15636  14612 S   0.0   0.4   0:04.94 systemd+
307 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
308 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
315 root      rt   0  290144  25984   7296 S   0.0   0.7   0:05.72 multipa+
379 root      20   0       0      0      0 S   0.0   0.0   0:00.00 jbd2/vd+
380 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
381 root      20   0   24824   6144   4480 S   0.0   0.2   0:02.89 systemd+
390 root      20   0       0      0      0 S   0.0   0.0   0:00.00 jbd2/vd+
392 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
394 root      20   0       0      0      0 S   0.0   0.0   0:00.00 jbd2/vd+
395 root       0 -20       0      0      0 I   0.0   0.0   0:00.00 kworker+
448 root      -2   0       0      0      0 S   0.0   0.0   0:00.00 psimon
455 systemd+  20   0   18700   8320   7296 S   0.0   0.2   0:00.94 systemd+
466 systemd+  20   0   21496  12032   9984 S   0.0   0.3   0:01.11 systemd+
470 systemd+  20   0   90760   6912   6144 S   0.0   0.2   0:00.86 systemd+
561 message+  20   0    9848   4224   3712 S   0.0   0.1   0:01.87 dbus-da+
564 polkitd   20   0  309068   7168   6400 S   0.0   0.2   0:02.45 polkitd
574 root      20   0   17908   7552   6656 S   0.0   0.2   0:01.79 systemd+
582 root      20   0  472564  12032  10240 S   0.0   0.3   0:02.42 udisksd
602 syslog    20   0  222812   4608   3712 S   0.0   0.1   0:01.37 rsyslogd
632 root      20   0  110896  21760  12544 S   0.0   0.6   0:01.33 unatten+
640 root      20   0  398868  11648   9728 S   0.0   0.3   0:02.49 ModemMa+
672 root      20   0    7148   2304   2176 S   0.0   0.1   0:00.27 cron
684 root      20   0   11832   3616   3200 S   0.0   0.1   0:00.67 login
694 root      20   0    5676   1536   1536 S   0.0   0.0   0:00.10 agetty
883 root      -2   0       0      0      0 S   0.0   0.0   0:00.00 psimon
886 root      20   0   19980  10496   8704 S   0.0   0.3   0:01.39 systemd
887 root      20   0   22200   3244   1792 S   0.0   0.1   0:00.00 (sd-pam)
892 root      -2   0       0      0      0 S   0.0   0.0   0:00.00 psimon
899 root      20   0    8900   4992   3328 S   0.0   0.1   0:00.72 bash
920 root      20   0   80260   2304   2048 S   0.0   0.1   0:00.13 tnAiHwR+
925 root      20   0    6364   1924   1664 S   0.0   0.1   0:00.00 tnApcMgr
936 root      20   0   12048   7168   6144 S   0.0   0.2   0:00.34 sshd
938 root      20   0   16364   9016   7424 S   0.0   0.3   0:00.59 sshd
993 root      20   0    8664   4864   3328 S   0.0   0.1   0:00.28 bash
1109 root      20   0  482468  39552  34816 S   0.0   1.1   0:03.61 fwupd
1128 root      20   0       0      0      0 I   0.0   0.0   0:00.02 kworker+
1239 root      20   0       0      0      0 I   0.0   0.0   0:00.34 kworker+
1243 root      20   0       0      0      0 I   0.0   0.0   0:00.05 kworker+
1254 root      20   0       0      0      0 I   0.0   0.0   0:00.00 kworker+
1441 root      20   0       0      0      0 I   0.0   0.0   0:00.04 kworker+
1558 root      20   0       0      0      0 I   0.0   0.0   0:00.03 kworker+
1633 root      20   0       0      0      0 I   0.0   0.0   0:00.10 kworker+
1636 root      20   0       0      0      0 I   0.0   0.0   0:00.00 kworker+
1663 root      20   0       0      0      0 I   0.0   0.0   0:00.09 kworker+
1831 root      20   0       0      0      0 I   0.0   0.0   0:00.07 kworker+
1968 root      20   0       0      0      0 I   0.0   0.0   0:00.04 kworker+
1982 root      20   0       0      0      0 I   0.0   0.0   0:00.00 kworker+
1984 root      20   0   16364   9080   7424 S   0.0   0.3   0:00.70 sshd
2040 root      20   0    8796   4864   3328 S   0.0   0.1   0:00.48 bash
2051 root      20   0       0      0      0 I   0.0   0.0   0:00.00 kworker+
