### PR TITLE
@VP-230: Updated abort to release OC for both FPGA and TSISIM

### DIFF
--- a/backend/open_webui/routers/flaskIfc/serial_script.py
+++ b/backend/open_webui/routers/flaskIfc/serial_script.py
@@ -90,8 +90,8 @@ def check_for_prompt(ser, timeout=10):
     return False
 
 
-def tsi_apc_manager_service_restart(ser):
-    ser.write(f"systemctl restart tsi-apc-manager\n".encode())
+def tsi_apc_manager_release_txe(ser):
+    ser.write(f"tsictl oc release 0\n".encode())
     if not check_for_prompt(ser, timeout=10):
         return None
 
@@ -106,7 +106,7 @@ def clean_up_after_abort(ser):
         print("Error: Linux prompt not detected, likely job or system is stuck")
         return False
     else:
-        tsi_apc_manager_service_restart(ser)
+        tsi_apc_manager_release_txe(ser)
         if not check_for_prompt(ser, 10):
             print(
                 "Warning: systemctl restart tsi-apc-manager did not respond to 'restart'."
@@ -115,7 +115,7 @@ def clean_up_after_abort(ser):
 
     ser.flush()
 
-    print("tsi-apc-manager restart successful.")
+    print("tsi-apc-manager txe release successful.")
     return True
 
 

--- a/backend/open_webui/routers/flaskIfc/serial_script_for_ssh.py
+++ b/backend/open_webui/routers/flaskIfc/serial_script_for_ssh.py
@@ -106,7 +106,7 @@ def check_for_prompt(shell, timeout=10):
 
 
 def tsi_apc_manager_service_release_txe(shell):
-    shell.send(f"tsictl txe release 0\n")
+    shell.send(f"tsictl oc release 0 1\n")
     if not check_for_prompt(shell, timeout=10):
         return None
 


### PR DESCRIPTION
This change does the following
1. Uses tsictl oc release instead of systemctl tsi-apc-manager
2. Releases both TXEs on TSISIM

When running prompt

OC 0::39,130: 
22:52:39,186:   oc-id                 : 0
22:52:39,186:   init-done             : yes
22:52:39,186:   va                    : 0xfc832d4f0000
22:52:39,187:   size                  : 1048576
22:52:39,187:   pa                    : 0x000000000d000000
22:52:39,187:   opu_boot_timestamp    : 2026-05-14 17:47:40.575
22:52:39,187:   opu_boot_count        : 1
22:52:39,188:   DB:
22:52:39,188:     agent-id         : 10000
22:52:39,188:     agent_status     : ALLOC
22:52:39,189:     group_identifier : 1
22:52:39,189:     num_allocs       : 2
22:52:39,189:     num_deallocs     : 1
22:52:39,189: OC 1:
22:52:39,189:   oc-id                 : 1
22:52:39,189:   init-done             : yes
22:52:39,189:   va                    : 0xfc832d3f0000
22:52:39,189:   size                  : 1048576
22:52:39,190:   pa                    : 0x000000000cc00000
22:52:39,190:   opu_boot_timestamp    : 2026-05-14 17:47:42.520
22:52:39,191:   opu_boot_count        : 1
22:52:39,191:   DB:
22:52:39,191:     agent-id         : 10001
22:52:39,192:     agent_status     : READY
22:52:39,192:     group_identifier : 0
22:52:39,192:     num_allocs       : 0
22:52:39,192:     num_deallocs     : 0

After prompt is aborted in between

22:52:39,198: root@tsisim:/opt/taos/app# tsictl oc show 
OC 0::49,395: 
22:52:49,456:   oc-id                 : 0
22:52:49,456:   init-done             : yes
22:52:49,457:   va                    : 0xfc832d4f0000
22:52:49,457:   size                  : 1048576
22:52:49,457:   pa                    : 0x000000000d000000
22:52:49,459:   opu_boot_timestamp    : 2026-05-14 17:47:40.575
22:52:49,460:   opu_boot_count        : 1
22:52:49,460:   DB:
22:52:49,460:     agent-id         : 10000
22:52:49,460:     agent_status     : READY
22:52:49,460:     group_identifier : 0
22:52:49,460:     num_allocs       : 2
22:52:49,460:     num_deallocs     : 2
22:52:49,461: OC 1:
22:52:49,461:   oc-id                 : 1
22:52:49,461:   init-done             : yes
22:52:49,461:   va                    : 0xfc832d3f0000
22:52:49,461:   size                  : 1048576
22:52:49,461:   pa                    : 0x000000000cc00000
22:52:49,462:   opu_boot_timestamp    : 2026-05-14 17:47:42.520
22:52:49,462:   opu_boot_count        : 1
22:52:49,462:   DB:
22:52:49,462:     agent-id         : 10001
22:52:49,462:     agent_status     : READY
22:52:49,462:     group_identifier : 0
22:52:49,462:     num_allocs       : 0
22:52:49,463:     num_deallocs     : 0
