### PR TITLE
@VP-275: Make the notification for new release to be disabled by default

### DIFF
--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -85,8 +85,8 @@
 	let stylizedPdfExport = true;
 
 	// Admin - Show Update Available Toast
-	let showUpdateToast = true;
-	let showChangelog = true;
+	let showUpdateToast = false;
+	let showChangelog = false;
 
 	let showEmojiInCall = false;
 	let voiceInterruption = false;
@@ -205,8 +205,8 @@
 		responseAutoCopy = $settings?.responseAutoCopy ?? false;
 
 		showUsername = $settings?.showUsername ?? false;
-		showUpdateToast = $settings?.showUpdateToast ?? true;
-		showChangelog = $settings?.showChangelog ?? true;
+		showUpdateToast = $settings?.showUpdateToast ?? false;
+		showChangelog = $settings?.showChangelog ?? false;
 
 		showEmojiInCall = $settings?.showEmojiInCall ?? false;
 		voiceInterruption = $settings?.voiceInterruption ?? false;

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -257,7 +257,7 @@
 		};
 		setupKeyboardShortcuts();
 
-		if ($user?.role === 'admin' && ($settings?.showChangelog ?? true)) {
+		if ($user?.role === 'admin' && ($settings?.showChangelog ?? false)) {
 			showChangelog.set($settings?.version !== $config.version);
 		}
 
@@ -303,7 +303,7 @@
 <SettingsModal bind:show={$showSettings} />
 <ChangelogModal bind:show={$showChangelog} />
 
-{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? true)}
+{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? false)}
 	<div class=" absolute bottom-8 right-8 z-50" in:fade={{ duration: 100 }}>
 		<UpdateInfoToast
 			{version}


### PR DESCRIPTION
This change disables the notification of release changes and the changes of updates and change log not to be displayed.

The logs before this change
<img width="1316" height="710" alt="Screenshot 2026-07-19 at 10 48 04 AM" src="https://github.com/user-attachments/assets/c35b375b-7874-4a3c-bd3a-ecced3c2b250" />
<img width="1485" height="746" alt="Screenshot 2026-07-19 at 10 47 52 AM" src="https://github.com/user-attachments/assets/4416d04d-9248-482b-b396-de9a21f51a6f" />
<img width="1309" height="748" alt="Screenshot 2026-07-19 at 10 50 18 AM" src="https://github.com/user-attachments/assets/e256dcb9-279d-44d5-9761-eeaf7b21fdcd" />

The logs after this changes
<img width="1322" height="751" alt="Screenshot 2026-07-19 at 10 29 59 AM" src="https://github.com/user-attachments/assets/6d6e5526-69fd-4e79-8aa5-18c9ffb02b20" />
<img width="1660" height="830" alt="Screenshot 2026-07-19 at 10 29 44 AM" src="https://github.com/user-attachments/assets/df7b4136-3366-429b-b1ea-c28637bb741b" />
